### PR TITLE
Changed JSON schema validator's options to remove warning: "$ref: key…

### DIFF
--- a/lib/specs/spec_0_2.js
+++ b/lib/specs/spec_0_2.js
@@ -16,8 +16,9 @@ const reserved = {
 
 const schema = require("../../ext/spec_0_2.json");
 
-// Default options
-const ajv = new Ajv();
+const ajv = new Ajv({
+  extendRefs: true //  validate all keywords in the schemas with $ref (the default behaviour in versions before 5.0.0)
+});
 
 const validate = ajv.compile(schema);
 


### PR DESCRIPTION
A fix for issue #7: $ref: keywords ignored in schema at path "#"