### PR TITLE
Make a copy of configuration being passed in

### DIFF
--- a/lib/bindings/http/binary_0_1.js
+++ b/lib/bindings/http/binary_0_1.js
@@ -1,7 +1,7 @@
 var axios = require("axios");
 
 function HTTPBinary(configuration){
-  this.config = configuration;
+  this.config = JSON.parse(JSON.stringify(configuration));
 
   this.config["headers"] = {
     "Content-Type":"application/cloudevents+json; charset=utf-8"

--- a/lib/bindings/http/binary_0_2.js
+++ b/lib/bindings/http/binary_0_2.js
@@ -2,7 +2,7 @@ var axios = require("axios");
 var empty = require("is-empty");
 
 function HTTPBinary(configuration){
-  this.config = configuration;
+  this.config = JSON.parse(JSON.stringify(configuration));
 
   this.config["headers"] = {
     "Content-Type":"application/cloudevents+json; charset=utf-8"

--- a/lib/bindings/http/structured_0_1.js
+++ b/lib/bindings/http/structured_0_1.js
@@ -1,7 +1,7 @@
 var axios = require("axios");
 
 function HTTPStructured(configuration){
-  this.config = configuration;
+  this.config = JSON.parse(JSON.stringify(configuration));
 
   this.config["headers"] = {
     "Content-Type":"application/cloudevents+json; charset=utf-8"
@@ -12,6 +12,7 @@ HTTPStructured.prototype.emit = function(cloudevent){
 
   // Create new request object
   var _config = JSON.parse(JSON.stringify(this.config));
+
 
   // Set the cloudevent payload
   _config["data"] = cloudevent.format();

--- a/lib/bindings/http/structured_0_2.js
+++ b/lib/bindings/http/structured_0_2.js
@@ -1,7 +1,7 @@
 var axios = require("axios");
 
 function HTTPStructured(configuration){
-  this.config = configuration;
+  this.config = JSON.parse(JSON.stringify(configuration));
 
   this.config["headers"] = {
     "Content-Type":"application/cloudevents+json; charset=utf-8"


### PR DESCRIPTION
Tests currently do not pass because the same config object is being used between the two bindings and the Content Type is being overridden. Changing the constructor to copy the config fixes this problem.