### PR TITLE
Fixing initialization of binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ var config = {
  */
 
 // The binding instance
-var binding = Cloudevent.bindings["http-structured0.1"](config);
+var binding = new Cloudevent.bindings["http-structured0.1"](config);
 
 // Emit the event using Promise
 binding.emit(cloudevent)


### PR DESCRIPTION
The following code:
```js
    const binding = Cloudevent.bindings["http-structured0.2"](config);
```
will return undefined. 

to create an instance we need to add the new keyword.