### PR TITLE
Remove non-existing fromString from README API doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,12 +252,6 @@ Object Cloudevent.format()
  * Format the payload as String.
  */
 String Cloudevent.toString()
-
-/*
- * Create a Cloudevent instance from String.
- */
-Cloudevent Cloudevent.fromString(String)
-
 ```
 
 ### `Formatter` classes


### PR DESCRIPTION
This commit removes the API documentation for the `fromString` Cloudevent
function as it does not seem to exist.