### PR TITLE
src: add eslint configuration and npm script

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,26 @@
+{
+  "extends": "eslint:recommended",
+  "env": {
+    "es6": true,
+    "node": true,
+    "mocha": true
+  },
+  "rules": {
+    "space-before-function-paren": ["error", "never"],
+    "standard/no-callback-literal": "off",
+    "arrow-spacing": "error",
+    "arrow-parens": ["error", "always"],
+    "arrow-body-style": ["error", "as-needed"],
+    "prefer-template": "error",
+    "max-len": ["warn", { "code": 80 }],
+    "no-unused-vars": ["warn", {
+      "argsIgnorePattern": "^_$|^e$|^reject$|^resolve$"
+    }],
+    "no-console": ["error", {
+      "allow": ["warn", "error"]
+    }],
+    "valid-jsdoc": "error",
+    "semi": ["error", "always"],
+    "quotes": ["error", "double", { "allowTemplateLiterals": true }]
+  }
+}

--- a/examples/express-ex/index.js
+++ b/examples/express-ex/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 const express = require("express");
 const app = express();
 
@@ -12,103 +14,101 @@ const structured1 = new v1.StructuredHTTPReceiver();
 const binary1 = new v1.BinaryHTTPReceiver();
 
 app.use((req, res, next) => {
-    let data="";
+  let data = "";
 
-    req.setEncoding("utf8");
-    req.on("data", function(chunk) {
-       data += chunk;
-    });
+  req.setEncoding("utf8");
+  req.on("data", function(chunk) {
+    data += chunk;
+  });
 
-    req.on("end", function() {
-        req.body = data;
-        next();
-    });
+  req.on("end", function() {
+    req.body = data;
+    next();
+  });
 });
 
-app.post("/v1", function (req, res) {
+app.post("/v1", function(req, res) {
   console.log(req.headers);
   console.log(req.body);
 
   try {
-    let myevent = structured1.parse(req.body, req.headers);
+    const myevent = structured1.parse(req.body, req.headers);
     // pretty print
     console.log("Accepted event:");
     console.log(JSON.stringify(myevent.format(), null, 2));
 
     res.status(201)
-          .json(myevent.format());
-
+      .json(myevent.format());
   } catch (err) {
     console.error(err);
     res.status(415)
-          .header("Content-Type", "application/json")
-          .send(JSON.stringify(err));
+      .header("Content-Type", "application/json")
+      .send(JSON.stringify(err));
   }
 });
 
-app.post("/v1/binary", function (req, res) {
+app.post("/v1/binary", function(req, res) {
   console.log(req.headers);
   console.log(req.body);
 
   try {
-    let myevent = binary1.parse(req.body, req.headers);
+    const myevent = binary1.parse(req.body, req.headers);
     // pretty print
     console.log("Accepted event:");
     console.log(JSON.stringify(myevent.format(), null, 2));
 
     res.status(201)
-          .json(myevent.format());
-
+      .json(myevent.format());
   } catch (err) {
     console.error(err);
     res.status(415)
-          .header("Content-Type", "application/json")
-          .send(JSON.stringify(err));
+      .header("Content-Type", "application/json")
+      .send(JSON.stringify(err));
   }
 });
 
-app.post("/v03", function (req, res) {
+app.post("/v03", function(req, res) {
   console.log(req.headers);
   console.log(req.body);
 
   unmarshaller03.unmarshall(req.body, req.headers)
-    .then(cloudevent => {
+    .then((cloudevent) => {
       // pretty print
       console.log("Accepted event:");
       console.log(JSON.stringify(cloudevent.format(), null, 2));
 
       res.status(201)
-            .json(cloudevent.format());
-  })
-  .catch(err => {
-    console.error(err);
-    res.status(415)
-          .header("Content-Type", "application/json")
-          .send(JSON.stringify(err));
-  });
+        .json(cloudevent.format());
+    })
+    .catch((err) => {
+      console.error(err);
+      res.status(415)
+        .header("Content-Type", "application/json")
+        .send(JSON.stringify(err));
+    });
 });
 
-app.post("/v02", function (req, res) {
+app.post("/v02", function(req, res) {
   console.log(req.headers);
   console.log(req.body);
 
   unmarshaller02.unmarshall(req.body, req.headers)
-    .then(cloudevent => {
+    .then((cloudevent) => {
       // pretty print
       console.log("Accepted event:");
       console.log(JSON.stringify(cloudevent.format(), null, 2));
 
       res.status(201)
-            .json(cloudevent.format());
-  })
-  .catch(err => {
-    console.error(err);
-    res.status(415)
-          .header("Content-Type", "application/json")
-          .send(JSON.stringify(err));
-  });
+        .json(cloudevent.format());
+    })
+    .catch((err) => {
+      console.error(err);
+      res.status(415)
+        .header("Content-Type", "application/json")
+        .send(JSON.stringify(err));
+    });
 });
 
-app.listen(3000, function () {
+app.listen(3000, function() {
   console.log("Example app listening on port 3000!");
 });

--- a/examples/typescript-ex/prettier.config.js
+++ b/examples/typescript-ex/prettier.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   singleQuote: true,
-  trailingComma: 'es5',
+  trailingComma: "es5"
 };

--- a/lib/bindings/http/commons.js
+++ b/lib/bindings/http/commons.js
@@ -2,18 +2,17 @@ const Constants = require("./constants.js");
 
 // Specific sanity for content-type header
 function sanityContentType(contentType) {
-  if(contentType) {
+  if (contentType) {
     return Array.of(contentType)
-              .map((c) => c.split(";"))
-              .map((c) => c.shift())
-              .shift();
+      .map((c) => c.split(";"))
+      .map((c) => c.shift())
+      .shift();
   }
 
   return contentType;
 }
 
 function sanityAndClone(headers) {
-
   const sanityHeaders = {};
 
   Array.from(Object.keys(headers))

--- a/lib/bindings/http/constants.js
+++ b/lib/bindings/http/constants.js
@@ -1,92 +1,92 @@
 // Commons
 module.exports = {
-  HEADERS : "headers",
-  CHARSET_DEFAULT : "utf-8",
+  HEADERS: "headers",
+  CHARSET_DEFAULT: "utf-8",
 
-  SPEC_V02 : "0.2",
-  SPEC_V03 : "0.3",
-  SPEC_V1  : "1.0",
+  SPEC_V02: "0.2",
+  SPEC_V03: "0.3",
+  SPEC_V1: "1.0",
 
-  DEFAULT_SPEC_VERSION_HEADER : "ce-specversion",
+  DEFAULT_SPEC_VERSION_HEADER: "ce-specversion",
 
-  ENCODING_BASE64 : "base64",
+  ENCODING_BASE64: "base64",
 
-  DATA_ATTRIBUTE : "data",
+  DATA_ATTRIBUTE: "data",
 
-  MIME_JSON         : "application/json",
-  MIME_OCTET_STREAM : "application/octet-stream",
-  MIME_CE           : "application/cloudevents",
-  MIME_CE_JSON      : "application/cloudevents+json",
+  MIME_JSON: "application/json",
+  MIME_OCTET_STREAM: "application/octet-stream",
+  MIME_CE: "application/cloudevents",
+  MIME_CE_JSON: "application/cloudevents+json",
 
-  HEADER_CONTENT_TYPE : "content-type",
+  HEADER_CONTENT_TYPE: "content-type",
 
-  DEFAULT_CONTENT_TYPE : "application/json; charset=utf-8",
-  DEFAULT_CE_CONTENT_TYPE : "application/cloudevents+json; charset=utf-8",
+  DEFAULT_CONTENT_TYPE: "application/json; charset=utf-8",
+  DEFAULT_CE_CONTENT_TYPE: "application/cloudevents+json; charset=utf-8",
 
-  BINARY_HEADERS_02 : {
-    TYPE              : "ce-type",
-    SPEC_VERSION      : "ce-specversion",
-    SOURCE            : "ce-source",
-    ID                : "ce-id",
-    TIME              : "ce-time",
-    SCHEMA_URL        : "ce-schemaurl",
-    EXTENSIONS_PREFIX : "ce-"
+  BINARY_HEADERS_02: {
+    TYPE: "ce-type",
+    SPEC_VERSION: "ce-specversion",
+    SOURCE: "ce-source",
+    ID: "ce-id",
+    TIME: "ce-time",
+    SCHEMA_URL: "ce-schemaurl",
+    EXTENSIONS_PREFIX: "ce-"
   },
-  STRUCTURED_ATTRS_02 : {
-    TYPE         : "type",
-    SPEC_VERSION : "specversion",
-    SOURCE       : "source",
-    ID           : "id",
-    TIME         : "time",
-    SCHEMA_URL   : "schemaurl",
-    CONTENT_TYPE : "contenttype",
-    DATA         : "data"
-  },
-
-  BINARY_HEADERS_03 : {
-    TYPE              : "ce-type",
-    SPEC_VERSION      : "ce-specversion",
-    SOURCE            : "ce-source",
-    ID                : "ce-id",
-    TIME              : "ce-time",
-    SCHEMA_URL        : "ce-schemaurl",
-    CONTENT_ENCONDING : "ce-datacontentencoding",
-    SUBJECT           : "ce-subject",
-    EXTENSIONS_PREFIX : "ce-"
-  },
-  STRUCTURED_ATTRS_03 : {
-    TYPE              : "type",
-    SPEC_VERSION      : "specversion",
-    SOURCE            : "source",
-    ID                : "id",
-    TIME              : "time",
-    SCHEMA_URL        : "schemaurl",
-    CONTENT_ENCONDING : "datacontentencoding",
-    CONTENT_TYPE      : "datacontenttype",
-    SUBJECT           : "subject",
-    DATA              : "data"
+  STRUCTURED_ATTRS_02: {
+    TYPE: "type",
+    SPEC_VERSION: "specversion",
+    SOURCE: "source",
+    ID: "id",
+    TIME: "time",
+    SCHEMA_URL: "schemaurl",
+    CONTENT_TYPE: "contenttype",
+    DATA: "data"
   },
 
-  BINARY_HEADERS_1 : {
-    TYPE              : "ce-type",
-    SPEC_VERSION      : "ce-specversion",
-    SOURCE            : "ce-source",
-    ID                : "ce-id",
-    TIME              : "ce-time",
-    DATA_SCHEMA       : "ce-dataschema",
-    SUBJECT           : "ce-subject",
-    EXTENSIONS_PREFIX : "ce-"
+  BINARY_HEADERS_03: {
+    TYPE: "ce-type",
+    SPEC_VERSION: "ce-specversion",
+    SOURCE: "ce-source",
+    ID: "ce-id",
+    TIME: "ce-time",
+    SCHEMA_URL: "ce-schemaurl",
+    CONTENT_ENCONDING: "ce-datacontentencoding",
+    SUBJECT: "ce-subject",
+    EXTENSIONS_PREFIX: "ce-"
   },
-  STRUCTURED_ATTRS_1 : {
-    TYPE              : "type",
-    SPEC_VERSION      : "specversion",
-    SOURCE            : "source",
-    ID                : "id",
-    TIME              : "time",
-    DATA_SCHEMA       : "dataschema",
-    CONTENT_TYPE      : "datacontenttype",
-    SUBJECT           : "subject",
-    DATA              : "data",
-    DATA_BASE64       : "data_base64"
+  STRUCTURED_ATTRS_03: {
+    TYPE: "type",
+    SPEC_VERSION: "specversion",
+    SOURCE: "source",
+    ID: "id",
+    TIME: "time",
+    SCHEMA_URL: "schemaurl",
+    CONTENT_ENCONDING: "datacontentencoding",
+    CONTENT_TYPE: "datacontenttype",
+    SUBJECT: "subject",
+    DATA: "data"
+  },
+
+  BINARY_HEADERS_1: {
+    TYPE: "ce-type",
+    SPEC_VERSION: "ce-specversion",
+    SOURCE: "ce-source",
+    ID: "ce-id",
+    TIME: "ce-time",
+    DATA_SCHEMA: "ce-dataschema",
+    SUBJECT: "ce-subject",
+    EXTENSIONS_PREFIX: "ce-"
+  },
+  STRUCTURED_ATTRS_1: {
+    TYPE: "type",
+    SPEC_VERSION: "specversion",
+    SOURCE: "source",
+    ID: "id",
+    TIME: "time",
+    DATA_SCHEMA: "dataschema",
+    CONTENT_TYPE: "datacontenttype",
+    SUBJECT: "subject",
+    DATA: "data",
+    DATA_BASE64: "data_base64"
   }
 };

--- a/lib/bindings/http/emitter_binary.js
+++ b/lib/bindings/http/emitter_binary.js
@@ -1,17 +1,18 @@
-var axios = require("axios");
+const axios = require("axios");
 
 const Constants = require("./constants.js");
 const defaults = {};
 defaults[Constants.HEADERS] = {};
-defaults[Constants.HEADERS][Constants.HEADER_CONTENT_TYPE] = Constants.DEFAULT_CONTENT_TYPE;
+defaults[Constants.HEADERS][Constants.HEADER_CONTENT_TYPE] =
+  Constants.DEFAULT_CONTENT_TYPE;
 
-function BinaryHTTPEmitter(config, headerByGetter, extensionPrefix){
+function BinaryHTTPEmitter(config, headerByGetter, extensionPrefix) {
   this.config = Object.assign({}, defaults, config);
   this.headerByGetter = headerByGetter;
   this.extensionPrefix = extensionPrefix;
 }
 
-BinaryHTTPEmitter.prototype.emit = function (cloudevent) {
+BinaryHTTPEmitter.prototype.emit = function(cloudevent) {
   const config = Object.assign({}, this.config);
   const headers = Object.assign({}, this.config[Constants.HEADERS]);
 
@@ -28,7 +29,7 @@ BinaryHTTPEmitter.prototype.emit = function (cloudevent) {
   // Set the cloudevent payload
   const formatted = cloudevent.format();
   let data = formatted.data;
-  data = (formatted.data_base64 ? formatted.data_base64: data);
+  data = (formatted.data_base64 ? formatted.data_base64 : data);
 
   // Have extensions?
   const exts = cloudevent.getExtensions();
@@ -41,8 +42,8 @@ BinaryHTTPEmitter.prototype.emit = function (cloudevent) {
   config[Constants.DATA_ATTRIBUTE] = data;
   config.headers = headers;
 
-    // Return the Promise
+  // Return the Promise
   return axios.request(config);
- };
+};
 
 module.exports = BinaryHTTPEmitter;

--- a/lib/bindings/http/emitter_binary_0_1.js
+++ b/lib/bindings/http/emitter_binary_0_1.js
@@ -4,70 +4,68 @@ const Constants = require("./constants.js");
 
 const headerByGetter = {};
 
-headerByGetter["getContenttype"] = {
-  name : Constants.HEADER_CONTENT_TYPE,
-  parser : (v) => v
+headerByGetter.getContenttype = {
+  name: Constants.HEADER_CONTENT_TYPE,
+  parser: (v) => v
 };
 
-headerByGetter["getType"] = {
-  name : "CE-EventType",
-  parser : (v) => v
+headerByGetter.getType = {
+  name: "CE-EventType",
+  parser: (v) => v
 };
 
-headerByGetter["getSpecversion"] = {
-  name : "CE-CloudEventsVersion",
-  parser : (v) => v
+headerByGetter.getSpecversion = {
+  name: "CE-CloudEventsVersion",
+  parser: (v) => v
 };
 
-headerByGetter["getSource"] = {
-  name : "CE-Source",
-  parser : (v) => v
+headerByGetter.getSource = {
+  name: "CE-Source",
+  parser: (v) => v
 };
 
-headerByGetter["getId"] = {
-  name : "CE-EventID",
-  parser : (v) => v
+headerByGetter.getId = {
+  name: "CE-EventID",
+  parser: (v) => v
 };
 
-headerByGetter["getEventTypeVersion"] = {
-  name : "CE-EventTypeVersion",
-  parser : (v) => v
+headerByGetter.getEventTypeVersion = {
+  name: "CE-EventTypeVersion",
+  parser: (v) => v
 };
 
-headerByGetter["getTime"] = {
-  name : "CE-EventTime",
-  parser : (v) => v
+headerByGetter.getTime = {
+  name: "CE-EventTime",
+  parser: (v) => v
 };
 
-headerByGetter["getSchemaurl"] = {
-  name : "CE-SchemaURL",
-  parser : (v) => v
+headerByGetter.getSchemaurl = {
+  name: "CE-SchemaURL",
+  parser: (v) => v
 };
 
-function HTTPBinary(configuration){
+function HTTPBinary(configuration) {
   this.config = JSON.parse(JSON.stringify(configuration));
 
-  if(!this.config["headers"]){
-    this.config["headers"] = {};
+  if (!this.config.headers) {
+    this.config.headers = {};
   }
 
-  this.config["headers"]
-    [Constants.HEADER_CONTENT_TYPE] =
-      Constants.MIME_JSON + "; charset=" + Constants.CHARSET_DEFAULT;
+  this.config.headers[Constants.HEADER_CONTENT_TYPE] =
+      `${Constants.MIME_JSON}; charset=${Constants.CHARSET_DEFAULT}`;
 }
 
-HTTPBinary.prototype.emit = function(cloudevent){
-
+HTTPBinary.prototype.emit = function(cloudevent) {
   // Create new request object
   const _config = JSON.parse(JSON.stringify(this.config));
 
   // Always set stuff in _config
-  const _headers = _config["headers"];
+  const _headers = _config.headers;
 
   Object.keys(headerByGetter)
     .filter((getter) => cloudevent[getter]())
     .forEach((getter) => {
-      let header = headerByGetter[getter];
+      const header = headerByGetter[getter];
       _headers[header.name] =
         header.parser(
           cloudevent[getter]()
@@ -75,15 +73,15 @@ HTTPBinary.prototype.emit = function(cloudevent){
     });
 
   // Set the cloudevent payload
-  _config["data"] = cloudevent.format().data;
+  _config.data = cloudevent.format().data;
 
   // EXTENSION CONTEXT ATTRIBUTES
   const exts = cloudevent.getExtensions();
   Object.keys(exts)
     .filter((ext) => Object.hasOwnProperty.call(exts, ext))
     .forEach((ext) => {
-      let capsExt = ext.charAt(0).toUpperCase() + ext.slice(1);
-      _headers["CE-X-" + capsExt] = exts[ext];
+      const capsExt = ext.charAt(0).toUpperCase() + ext.slice(1);
+      _headers[`CE-X-${capsExt}`] = exts[ext];
     });
 
   // Return the Promise

--- a/lib/bindings/http/emitter_binary_0_2.js
+++ b/lib/bindings/http/emitter_binary_0_2.js
@@ -4,42 +4,42 @@ const Constants = require("./constants.js");
 
 const headerByGetter = {};
 
-headerByGetter["getContenttype"] = {
-  name : Constants.HEADER_CONTENT_TYPE,
-  parser : (v) => v
+headerByGetter.getContenttype = {
+  name: Constants.HEADER_CONTENT_TYPE,
+  parser: (v) => v
 };
 
-headerByGetter["getType"] = {
-  name : Constants.BINARY_HEADERS_02.TYPE,
-  parser : (v) => v
+headerByGetter.getType = {
+  name: Constants.BINARY_HEADERS_02.TYPE,
+  parser: (v) => v
 };
 
-headerByGetter["getSpecversion"] = {
-  name : Constants.BINARY_HEADERS_02.SPEC_VERSION,
-  parser : (v) => v
+headerByGetter.getSpecversion = {
+  name: Constants.BINARY_HEADERS_02.SPEC_VERSION,
+  parser: (v) => v
 };
 
-headerByGetter["getSource"] = {
-  name : Constants.BINARY_HEADERS_02.SOURCE,
-  parser : (v) => v
+headerByGetter.getSource = {
+  name: Constants.BINARY_HEADERS_02.SOURCE,
+  parser: (v) => v
 };
 
-headerByGetter["getId"] = {
-  name : Constants.BINARY_HEADERS_02.ID,
-  parser : (v) => v
+headerByGetter.getId = {
+  name: Constants.BINARY_HEADERS_02.ID,
+  parser: (v) => v
 };
 
-headerByGetter["getTime"] = {
-  name : Constants.BINARY_HEADERS_02.TIME,
-  parser : (v) => v
+headerByGetter.getTime = {
+  name: Constants.BINARY_HEADERS_02.TIME,
+  parser: (v) => v
 };
 
-headerByGetter["getSchemaurl"] = {
-  name : Constants.BINARY_HEADERS_02.SCHEMA_URL,
-  parser : (v) => v
+headerByGetter.getSchemaurl = {
+  name: Constants.BINARY_HEADERS_02.SCHEMA_URL,
+  parser: (v) => v
 };
 
-function HTTPBinary02(configuration){
+function HTTPBinary02(configuration) {
   this.emitter = new BinaryHTTPEmitter(
     configuration,
     headerByGetter,
@@ -47,7 +47,7 @@ function HTTPBinary02(configuration){
   );
 }
 
-HTTPBinary02.prototype.emit = function(cloudevent){
+HTTPBinary02.prototype.emit = function(cloudevent) {
   return this.emitter.emit(cloudevent);
 };
 

--- a/lib/bindings/http/emitter_binary_0_3.js
+++ b/lib/bindings/http/emitter_binary_0_3.js
@@ -4,52 +4,52 @@ const Constants = require("./constants.js");
 
 const headerByGetter = {};
 
-headerByGetter["getDataContentType"] = {
-  name : Constants.HEADER_CONTENT_TYPE,
-  parser : (v) => v
+headerByGetter.getDataContentType = {
+  name: Constants.HEADER_CONTENT_TYPE,
+  parser: (v) => v
 };
 
-headerByGetter["getDataContentEncoding"] = {
-  name : Constants.BINARY_HEADERS_03.CONTENT_ENCONDING,
-  parser : (v) => v
+headerByGetter.getDataContentEncoding = {
+  name: Constants.BINARY_HEADERS_03.CONTENT_ENCONDING,
+  parser: (v) => v
 };
 
-headerByGetter["getSubject"] = {
-  name : Constants.BINARY_HEADERS_03.SUBJECT,
-  parser : (v) => v
+headerByGetter.getSubject = {
+  name: Constants.BINARY_HEADERS_03.SUBJECT,
+  parser: (v) => v
 };
 
-headerByGetter["getType"] = {
-  name : Constants.BINARY_HEADERS_03.TYPE,
-  parser : (v) => v
+headerByGetter.getType = {
+  name: Constants.BINARY_HEADERS_03.TYPE,
+  parser: (v) => v
 };
 
-headerByGetter["getSpecversion"] = {
-  name : Constants.BINARY_HEADERS_03.SPEC_VERSION,
-  parser : (v) => v
+headerByGetter.getSpecversion = {
+  name: Constants.BINARY_HEADERS_03.SPEC_VERSION,
+  parser: (v) => v
 };
 
-headerByGetter["getSource"] = {
-  name : Constants.BINARY_HEADERS_03.SOURCE,
-  parser : (v) => v
+headerByGetter.getSource = {
+  name: Constants.BINARY_HEADERS_03.SOURCE,
+  parser: (v) => v
 };
 
-headerByGetter["getId"] = {
-  name : Constants.BINARY_HEADERS_03.ID,
-  parser : (v) => v
+headerByGetter.getId = {
+  name: Constants.BINARY_HEADERS_03.ID,
+  parser: (v) => v
 };
 
-headerByGetter["getTime"] = {
-  name : Constants.BINARY_HEADERS_03.TIME,
-  parser : (v) => v
+headerByGetter.getTime = {
+  name: Constants.BINARY_HEADERS_03.TIME,
+  parser: (v) => v
 };
 
-headerByGetter["getSchemaurl"] = {
-  name : Constants.BINARY_HEADERS_03.SCHEMA_URL,
-  parser : (v) => v
+headerByGetter.getSchemaurl = {
+  name: Constants.BINARY_HEADERS_03.SCHEMA_URL,
+  parser: (v) => v
 };
 
-function HTTPBinary(configuration){
+function HTTPBinary(configuration) {
   this.emitter = new BinaryHTTPEmitter(
     configuration,
     headerByGetter,
@@ -57,7 +57,7 @@ function HTTPBinary(configuration){
   );
 }
 
-HTTPBinary.prototype.emit = function(cloudevent){
+HTTPBinary.prototype.emit = function(cloudevent) {
   return this.emitter.emit(cloudevent);
 };
 

--- a/lib/bindings/http/emitter_binary_1.js
+++ b/lib/bindings/http/emitter_binary_1.js
@@ -4,47 +4,47 @@ const Constants = require("./constants.js");
 
 const headerByGetter = {};
 
-headerByGetter["getDataContentType"] = {
-  name : Constants.HEADER_CONTENT_TYPE,
-  parser : (v) => v
+headerByGetter.getDataContentType = {
+  name: Constants.HEADER_CONTENT_TYPE,
+  parser: (v) => v
 };
 
-headerByGetter["getSubject"] = {
-  name : Constants.BINARY_HEADERS_1.SUBJECT,
-  parser : (v) => v
+headerByGetter.getSubject = {
+  name: Constants.BINARY_HEADERS_1.SUBJECT,
+  parser: (v) => v
 };
 
-headerByGetter["getType"] = {
-  name : Constants.BINARY_HEADERS_1.TYPE,
-  parser : (v) => v
+headerByGetter.getType = {
+  name: Constants.BINARY_HEADERS_1.TYPE,
+  parser: (v) => v
 };
 
-headerByGetter["getSpecversion"] = {
-  name : Constants.BINARY_HEADERS_1.SPEC_VERSION,
-  parser : (v) => v
+headerByGetter.getSpecversion = {
+  name: Constants.BINARY_HEADERS_1.SPEC_VERSION,
+  parser: (v) => v
 };
 
-headerByGetter["getSource"] = {
-  name : Constants.BINARY_HEADERS_1.SOURCE,
-  parser : (v) => v
+headerByGetter.getSource = {
+  name: Constants.BINARY_HEADERS_1.SOURCE,
+  parser: (v) => v
 };
 
-headerByGetter["getId"] = {
-  name : Constants.BINARY_HEADERS_1.ID,
-  parser : (v) => v
+headerByGetter.getId = {
+  name: Constants.BINARY_HEADERS_1.ID,
+  parser: (v) => v
 };
 
-headerByGetter["getTime"] = {
-  name : Constants.BINARY_HEADERS_1.TIME,
-  parser : (v) => v
+headerByGetter.getTime = {
+  name: Constants.BINARY_HEADERS_1.TIME,
+  parser: (v) => v
 };
 
-headerByGetter["getDataschema"] = {
-  name : Constants.BINARY_HEADERS_1.DATA_SCHEMA,
-  parser : (v) => v
+headerByGetter.getDataschema = {
+  name: Constants.BINARY_HEADERS_1.DATA_SCHEMA,
+  parser: (v) => v
 };
 
-function HTTPBinary(configuration){
+function HTTPBinary(configuration) {
   this.emitter = new BinaryHTTPEmitter(
     configuration,
     headerByGetter,
@@ -52,7 +52,7 @@ function HTTPBinary(configuration){
   );
 }
 
-HTTPBinary.prototype.emit = function(cloudevent){
+HTTPBinary.prototype.emit = function(cloudevent) {
   return this.emitter.emit(cloudevent);
 };
 

--- a/lib/bindings/http/emitter_structured.js
+++ b/lib/bindings/http/emitter_structured.js
@@ -3,13 +3,14 @@ const axios = require("axios");
 const Constants = require("./constants.js");
 const defaults = {};
 defaults[Constants.HEADERS] = {};
-defaults[Constants.HEADERS][Constants.HEADER_CONTENT_TYPE] = Constants.DEFAULT_CE_CONTENT_TYPE;
+defaults[Constants.HEADERS][Constants.HEADER_CONTENT_TYPE] =
+  Constants.DEFAULT_CE_CONTENT_TYPE;
 
-function StructuredHTTPEmitter(configuration){
+function StructuredHTTPEmitter(configuration) {
   this.config = Object.assign({}, defaults, configuration);
 }
 
-StructuredHTTPEmitter.prototype.emit = function (cloudevent) {
+StructuredHTTPEmitter.prototype.emit = function(cloudevent) {
   // Set the cloudevent payload
   this.config[Constants.DATA_ATTRIBUTE] = cloudevent.format();
 

--- a/lib/bindings/http/emitter_structured_0_1.js
+++ b/lib/bindings/http/emitter_structured_0_1.js
@@ -2,26 +2,23 @@ const axios = require("axios");
 
 const Constants = require("./constants.js");
 
-function HTTPStructured(configuration){
+function HTTPStructured(configuration) {
   this.config = JSON.parse(JSON.stringify(configuration));
 
-  if(!this.config["headers"]){
-    this.config["headers"] = {};
+  if (!this.config.headers) {
+    this.config.headers = {};
   }
 
-  this.config["headers"]
-    [Constants.HEADER_CONTENT_TYPE] =
-      Constants.MIME_CE_JSON + "; charset=" + Constants.CHARSET_DEFAULT;
+  this.config.headers[Constants.HEADER_CONTENT_TYPE] =
+      `${Constants.MIME_CE_JSON}; charset=${Constants.CHARSET_DEFAULT}`;
 }
 
-HTTPStructured.prototype.emit = function(cloudevent){
-
+HTTPStructured.prototype.emit = function(cloudevent) {
   // Create new request object
   const _config = JSON.parse(JSON.stringify(this.config));
 
-
   // Set the cloudevent payload
-  _config["data"] = cloudevent.format();
+  _config.data = cloudevent.format();
 
   // Return the Promise
   return axios.request(_config);

--- a/lib/bindings/http/emitter_structured_0_2.js
+++ b/lib/bindings/http/emitter_structured_0_2.js
@@ -1,10 +1,10 @@
 const StructuredHTTPEmitter = require("./emitter_structured.js");
 
-function HTTPStructured(configuration){
+function HTTPStructured(configuration) {
   this.emitter = new StructuredHTTPEmitter(configuration);
 }
 
-HTTPStructured.prototype.emit = function(cloudevent){
+HTTPStructured.prototype.emit = function(cloudevent) {
   return this.emitter.emit(cloudevent);
 };
 

--- a/lib/bindings/http/receiver_binary.js
+++ b/lib/bindings/http/receiver_binary.js
@@ -1,5 +1,5 @@
-const Constants  = require("./constants.js");
-const Commons    = require("./commons.js");
+const Constants = require("./constants.js");
+const Commons = require("./commons.js");
 const Cloudevent = require("../../cloudevent.js");
 
 const {
@@ -8,17 +8,16 @@ const {
 } = require("../../utils/fun.js");
 
 function validateArgs(payload, attributes) {
-
   Array.of(payload)
     .filter((p) => isDefinedOrThrow(p,
-              {message: "payload is null or undefined"}))
+      { message: "payload is null or undefined" }))
     .filter((p) => isStringOrObjectOrThrow(p,
-              {message: "payload must be an object or a string"}))
+      { message: "payload must be an object or a string" }))
     .shift();
 
   Array.of(attributes)
     .filter((a) => isDefinedOrThrow(a,
-                {message: "attributes is null or undefined"}))
+      { message: "attributes is null or undefined" }))
     .shift();
 }
 
@@ -31,7 +30,6 @@ function BinaryHTTPReceiver(
   specversion,
   extensionsPrefix,
   checkDecorator) {
-
   this.parsersByEncoding = parsersByEncoding;
   this.setterByHeader = setterByHeader;
   this.allowedContentTypes = allowedContentTypes;
@@ -47,7 +45,7 @@ BinaryHTTPReceiver.prototype.check = function(payload, headers) {
   // Validation Level 0
   validateArgs(payload, headers);
 
-  if(this.checkDecorator) {
+  if (this.checkDecorator) {
     this.checkDecorator(payload, headers);
   }
 
@@ -55,32 +53,31 @@ BinaryHTTPReceiver.prototype.check = function(payload, headers) {
   const sanityHeaders = Commons.sanityAndClone(headers);
 
   // Validation Level 1
-  if(!this.allowedContentTypes
-      .includes(sanityHeaders[Constants.HEADER_CONTENT_TYPE])){
-        throw {
-          message: "invalid content type",
-          errors: [sanityHeaders[Constants.HEADER_CONTENT_TYPE]]
-        };
+  if (!this.allowedContentTypes
+    .includes(sanityHeaders[Constants.HEADER_CONTENT_TYPE])) {
+    const err = new TypeError("invalid content type");
+    err.errors = [sanityHeaders[Constants.HEADER_CONTENT_TYPE]];
+    throw err;
   }
 
   this.requiredHeaders
     .filter((required) => !sanityHeaders[required])
     .forEach((required) => {
-      throw {message: "header '" + required + "' not found"};
+      throw new TypeError(`header '${required}' not found`);
     });
 
-  if(sanityHeaders[Constants.DEFAULT_SPEC_VERSION_HEADER] !== this.specversion){
-    throw {
-      message: "invalid spec version",
-      errors: [sanityHeaders[Constants.DEFAULT_SPEC_VERSION_HEADER]]
-    };
+  if (sanityHeaders[Constants.DEFAULT_SPEC_VERSION_HEADER] !==
+    this.specversion) {
+    const err = new TypeError("invalid spec version");
+    err.errors = [sanityHeaders[Constants.DEFAULT_SPEC_VERSION_HEADER]];
+    throw err;
   }
 
   // No erros! Its contains the minimum required attributes
 };
 
-function parserFor(parsersByEncoding, cloudevent, headers){
-  let encoding = cloudevent.spec.payload["datacontentencoding"];
+function parserFor(parsersByEncoding, cloudevent, headers) {
+  const encoding = cloudevent.spec.payload.datacontentencoding;
   return parsersByEncoding[encoding][headers[Constants.HEADER_CONTENT_TYPE]];
 }
 
@@ -98,7 +95,7 @@ BinaryHTTPReceiver.prototype.parse = function(payload, headers) {
     .filter((header) => sanityHeaders[header])
     .forEach((header) => {
       const setterName = this.setterByHeader[header].name;
-      const parserFun   = this.setterByHeader[header].parser;
+      const parserFun = this.setterByHeader[header].parser;
 
       // invoke the setter function
       cloudevent[setterName](parserFun(sanityHeaders[header]));
@@ -108,21 +105,21 @@ BinaryHTTPReceiver.prototype.parse = function(payload, headers) {
     });
 
   // Parses the payload
-  let parsedPayload =
+  const parsedPayload =
       parserFor(this.parsersByEncoding, cloudevent, sanityHeaders)
         .parse(payload);
 
   // Every unprocessed header can be an extension
   Array.from(Object.keys(sanityHeaders))
-  .filter((value) => !processedHeaders.includes(value))
-  .filter((value) =>
-    value.startsWith(this.extensionsPrefix))
-  .map((extension) =>
-    extension.substring(this.extensionsPrefix.length)
-  ).forEach((extension) =>
-    cloudevent.addExtension(extension,
-      sanityHeaders[this.extensionsPrefix+extension])
-  );
+    .filter((value) => !processedHeaders.includes(value))
+    .filter((value) =>
+      value.startsWith(this.extensionsPrefix))
+    .map((extension) =>
+      extension.substring(this.extensionsPrefix.length)
+    ).forEach((extension) =>
+      cloudevent.addExtension(extension,
+        sanityHeaders[this.extensionsPrefix + extension])
+    );
 
   // Sets the data
   cloudevent.data(parsedPayload);

--- a/lib/bindings/http/receiver_binary_0_2.js
+++ b/lib/bindings/http/receiver_binary_0_2.js
@@ -1,14 +1,8 @@
-const Constants  = require("./constants.js");
-const Spec02     = require("../../specs/spec_0_2.js");
+const Constants = require("./constants.js");
+const Spec02 = require("../../specs/spec_0_2.js");
 
 const JSONParser = require("../../formats/json/parser.js");
-
 const BinaryHTTPReceiver = require("./receiver_binary.js");
-
-const {
-  isDefinedOrThrow,
-  isStringOrObjectOrThrow
-} = require("../../utils/fun.js");
 
 const parserByType = {};
 parserByType[Constants.MIME_JSON] = new JSONParser();
@@ -17,7 +11,7 @@ parserByType[Constants.MIME_OCTET_STREAM] = {
 };
 
 const parsersByEncoding = {};
-parsersByEncoding[null] = parserByType;
+parsersByEncoding.null = parserByType;
 parsersByEncoding[undefined] = parserByType;
 
 const allowedContentTypes = [];
@@ -32,24 +26,24 @@ requiredHeaders.push(Constants.BINARY_HEADERS_02.ID);
 
 const setterByHeader = {};
 setterByHeader[Constants.BINARY_HEADERS_02.TYPE] = {
-  name : "type",
-  parser : (v) => v
+  name: "type",
+  parser: (v) => v
 };
 setterByHeader[Constants.BINARY_HEADERS_02.SPEC_VERSION] = {
-  name : "specversion",
-  parser : (v) => "0.2"
+  name: "specversion",
+  parser: () => "0.2"
 };
 setterByHeader[Constants.BINARY_HEADERS_02.SOURCE] = {
-  name : "source",
+  name: "source",
   parser: (v) => v
 };
 setterByHeader[Constants.BINARY_HEADERS_02.ID] = {
-  name : "id",
-  parser : (v) => v
+  name: "id",
+  parser: (v) => v
 };
 setterByHeader[Constants.BINARY_HEADERS_02.TIME] = {
-  name : "time",
-  parser : (v) => new Date(Date.parse(v))
+  name: "time",
+  parser: (v) => new Date(Date.parse(v))
 };
 setterByHeader[Constants.BINARY_HEADERS_02.SCHEMA_URL] = {
   name: "schemaurl",
@@ -60,6 +54,8 @@ setterByHeader[Constants.HEADER_CONTENT_TYPE] = {
   parser: (v) => v
 };
 
+// Leaving this in place for now. TODO: fixme
+// eslint-disable-next-line
 function Receiver(configuration) {
   this.receiver = new BinaryHTTPReceiver(
     parsersByEncoding,

--- a/lib/bindings/http/receiver_binary_0_3.js
+++ b/lib/bindings/http/receiver_binary_0_3.js
@@ -1,15 +1,10 @@
-const Constants  = require("./constants.js");
-const Spec     = require("../../specs/spec_0_3.js");
+const Constants = require("./constants.js");
+const Spec = require("../../specs/spec_0_3.js");
 
 const JSONParser = require("../../formats/json/parser.js");
 const Base64Parser = require("../../formats/base64.js");
 
 const BinaryHTTPReceiver = require("./receiver_binary.js");
-
-const {
-  isDefinedOrThrow,
-  isStringOrObjectOrThrow
-} = require("../../utils/fun.js");
 
 const parserByType = {};
 parserByType[Constants.MIME_JSON] = new JSONParser();
@@ -18,7 +13,7 @@ parserByType[Constants.MIME_OCTET_STREAM] = {
 };
 
 const parsersByEncoding = {};
-parsersByEncoding[null] = parserByType;
+parsersByEncoding.null = parserByType;
 parsersByEncoding[undefined] = parserByType;
 
 // base64
@@ -44,24 +39,24 @@ requiredHeaders.push(Constants.BINARY_HEADERS_03.ID);
 
 const setterByHeader = {};
 setterByHeader[Constants.BINARY_HEADERS_03.TYPE] = {
-  name : "type",
-  parser : (v) => v
+  name: "type",
+  parser: (v) => v
 };
 setterByHeader[Constants.BINARY_HEADERS_03.SPEC_VERSION] = {
-  name : "specversion",
-  parser : (v) => "0.3"
+  name: "specversion",
+  parser: () => "0.3"
 };
 setterByHeader[Constants.BINARY_HEADERS_03.SOURCE] = {
-  name : "source",
+  name: "source",
   parser: (v) => v
 };
 setterByHeader[Constants.BINARY_HEADERS_03.ID] = {
-  name : "id",
-  parser : (v) => v
+  name: "id",
+  parser: (v) => v
 };
 setterByHeader[Constants.BINARY_HEADERS_03.TIME] = {
-  name : "time",
-  parser : (v) => new Date(Date.parse(v))
+  name: "time",
+  parser: (v) => new Date(Date.parse(v))
 };
 setterByHeader[Constants.BINARY_HEADERS_03.SCHEMA_URL] = {
   name: "schemaurl",
@@ -80,19 +75,24 @@ setterByHeader[Constants.BINARY_HEADERS_03.SUBJECT] = {
   parser: (v) => v
 };
 
+// Leaving this in place for now. TODO: fixme
+// eslint-disable-next-line
 function checkDecorator(payload, headers) {
   Object.keys(headers)
     .map((header) => header.toLocaleLowerCase("en-US"))
     .filter((header) =>
-              header === Constants.BINARY_HEADERS_03.CONTENT_ENCONDING)
+      header === Constants.BINARY_HEADERS_03.CONTENT_ENCONDING)
     .filter((header) => !allowedEncodings.includes(headers[header]))
     .forEach((header) => {
-      throw {message : "unsupported datacontentencoding", errors: [
-        headers[header]
-      ]};
+      // TODO: using forEach here seems off
+      const err = new TypeError("unsupported datacontentencoding");
+      err.errors = [headers[header]];
+      throw err;
     });
 }
 
+// Leaving this in place for now. TODO: fixme
+// eslint-disable-next-line
 function Receiver(configuration) {
   this.receiver = new BinaryHTTPReceiver(
     parsersByEncoding,

--- a/lib/bindings/http/receiver_binary_1.js
+++ b/lib/bindings/http/receiver_binary_1.js
@@ -1,5 +1,5 @@
-const Constants  = require("./constants.js");
-const Spec     = require("../../specs/spec_1.js");
+const Constants = require("./constants.js");
+const Spec = require("../../specs/spec_1.js");
 
 const JSONParser = require("../../formats/json/parser.js");
 const Base64Parser = require("../../formats/base64.js");
@@ -7,8 +7,6 @@ const Base64Parser = require("../../formats/base64.js");
 const BinaryHTTPReceiver = require("./receiver_binary.js");
 
 const {
-  isDefinedOrThrow,
-  isStringOrObjectOrThrow,
   isString,
   isBase64
 } = require("../../utils/fun.js");
@@ -20,7 +18,7 @@ parserByType[Constants.MIME_OCTET_STREAM] = {
 };
 
 const parsersByEncoding = {};
-parsersByEncoding[null] = parserByType;
+parsersByEncoding.null = parserByType;
 parsersByEncoding[undefined] = parserByType;
 
 // base64
@@ -46,24 +44,24 @@ requiredHeaders.push(Constants.BINARY_HEADERS_1.ID);
 
 const setterByHeader = {};
 setterByHeader[Constants.BINARY_HEADERS_1.TYPE] = {
-  name : "type",
-  parser : (v) => v
+  name: "type",
+  parser: (v) => v
 };
 setterByHeader[Constants.BINARY_HEADERS_1.SPEC_VERSION] = {
-  name : "specversion",
-  parser : (v) => "1.0"
+  name: "specversion",
+  parser: () => "1.0"
 };
 setterByHeader[Constants.BINARY_HEADERS_1.SOURCE] = {
-  name : "source",
+  name: "source",
   parser: (v) => v
 };
 setterByHeader[Constants.BINARY_HEADERS_1.ID] = {
-  name : "id",
-  parser : (v) => v
+  name: "id",
+  parser: (v) => v
 };
 setterByHeader[Constants.BINARY_HEADERS_1.TIME] = {
-  name : "time",
-  parser : (v) => new Date(Date.parse(v))
+  name: "time",
+  parser: (v) => new Date(Date.parse(v))
 };
 setterByHeader[Constants.BINARY_HEADERS_1.DATA_SCHEMA] = {
   name: "dataschema",
@@ -78,9 +76,13 @@ setterByHeader[Constants.BINARY_HEADERS_1.SUBJECT] = {
   parser: (v) => v
 };
 
+// Leaving these in place for now. TODO: fixme
+// eslint-disable-next-line
 function checkDecorator(payload, headers) {
 }
 
+// Leaving this in place for now. TODO: fixme
+// eslint-disable-next-line
 function Receiver(configuration) {
   this.receiver = new BinaryHTTPReceiver(
     parsersByEncoding,

--- a/lib/bindings/http/receiver_structured.js
+++ b/lib/bindings/http/receiver_structured.js
@@ -1,5 +1,5 @@
-const Constants  = require("./constants.js");
-const Commons    = require("./commons.js");
+const Constants = require("./constants.js");
+const Commons = require("./commons.js");
 const Cloudevent = require("../../cloudevent.js");
 
 const {
@@ -10,14 +10,14 @@ const {
 function validateArgs(payload, attributes) {
   Array.of(payload)
     .filter((p) => isDefinedOrThrow(p,
-              {message: "payload is null or undefined"}))
+      { message: "payload is null or undefined" }))
     .filter((p) => isStringOrObjectOrThrow(p,
-              {message: "payload must be an object or string"}))
+      { message: "payload must be an object or string" }))
     .shift();
 
   Array.of(attributes)
     .filter((a) => isDefinedOrThrow(a,
-                {message: "attributes is null or undefined"}))
+      { message: "attributes is null or undefined" }))
     .shift();
 }
 
@@ -26,7 +26,6 @@ function StructuredHTTPReceiver(
   setterByAttribute,
   allowedContentTypes,
   Spec) {
-
   this.parserByMime = parserByMime;
   this.setterByAttribute = setterByAttribute;
   this.allowedContentTypes = allowedContentTypes;
@@ -40,12 +39,11 @@ StructuredHTTPReceiver.prototype.check = function(payload, headers) {
   const sanityHeaders = Commons.sanityAndClone(headers);
 
   // Validation Level 1
-  if(!this.allowedContentTypes
-      .includes(sanityHeaders[Constants.HEADER_CONTENT_TYPE])){
-        throw {
-          message: "invalid content type",
-          errors: [sanityHeaders[Constants.HEADER_CONTENT_TYPE]]
-        };
+  if (!this.allowedContentTypes
+    .includes(sanityHeaders[Constants.HEADER_CONTENT_TYPE])) {
+    const err = new TypeError("invalid content type");
+    err.errors = [sanityHeaders[Constants.HEADER_CONTENT_TYPE]];
+    throw err;
   }
 
   // No erros! Its contains the minimum required attributes
@@ -59,7 +57,7 @@ StructuredHTTPReceiver.prototype.parse = function(payload, headers) {
   const contentType = sanityHeaders[Constants.HEADER_CONTENT_TYPE];
 
   const parser = this.parserByMime[contentType];
-  const event  = parser.parse(payload);
+  const event = parser.parse(payload);
   this.spec.check(event);
 
   const processedAttributes = [];
@@ -68,8 +66,8 @@ StructuredHTTPReceiver.prototype.parse = function(payload, headers) {
   Array.from(Object.keys(this.setterByAttribute))
     .filter((attribute) => event[attribute])
     .forEach((attribute) => {
-      let setterName = this.setterByAttribute[attribute].name;
-      let parserFun  = this.setterByAttribute[attribute].parser;
+      const setterName = this.setterByAttribute[attribute].name;
+      const parserFun = this.setterByAttribute[attribute].parser;
 
       // invoke the setter function
       cloudevent[setterName](parserFun(event[attribute]));

--- a/lib/bindings/http/receiver_structured_0_2.js
+++ b/lib/bindings/http/receiver_structured_0_2.js
@@ -1,18 +1,13 @@
 const Constants = require("./constants.js");
-const Spec02    = require("../../specs/spec_0_2.js");
-const JSONParser  = require("../../formats/json/parser.js");
+const Spec02 = require("../../specs/spec_0_2.js");
+const JSONParser = require("../../formats/json/parser.js");
 
 const StructuredHTTPReceiver = require("./receiver_structured.js");
-
-const {
-  isDefinedOrThrow,
-  isStringOrObjectOrThrow
-} = require("../../utils/fun.js");
 
 const jsonParserSpec02 = new JSONParser();
 
 const parserByMime = {};
-parserByMime[Constants.MIME_JSON]    = jsonParserSpec02;
+parserByMime[Constants.MIME_JSON] = jsonParserSpec02;
 parserByMime[Constants.MIME_CE_JSON] = jsonParserSpec02;
 
 const allowedContentTypes = [];
@@ -20,24 +15,24 @@ allowedContentTypes.push(Constants.MIME_CE_JSON);
 
 const setterByAttribute = {};
 setterByAttribute[Constants.STRUCTURED_ATTRS_02.TYPE] = {
-  name : "type",
-  parser : (v) => v
+  name: "type",
+  parser: (v) => v
 };
 setterByAttribute[Constants.STRUCTURED_ATTRS_02.SPEC_VERSION] = {
-  name : "specversion",
-  parser : (v) => v
+  name: "specversion",
+  parser: (v) => v
 };
 setterByAttribute[Constants.STRUCTURED_ATTRS_02.SOURCE] = {
-  name : "source",
+  name: "source",
   parser: (v) => v
 };
 setterByAttribute[Constants.STRUCTURED_ATTRS_02.ID] = {
-  name : "id",
-  parser : (v) => v
+  name: "id",
+  parser: (v) => v
 };
 setterByAttribute[Constants.STRUCTURED_ATTRS_02.TIME] = {
-  name : "time",
-  parser : (v) => new Date(Date.parse(v))
+  name: "time",
+  parser: (v) => new Date(Date.parse(v))
 };
 setterByAttribute[Constants.STRUCTURED_ATTRS_02.SCHEMA_URL] = {
   name: "schemaurl",
@@ -52,6 +47,8 @@ setterByAttribute[Constants.STRUCTURED_ATTRS_02.DATA] = {
   parser: (v) => v
 };
 
+// Leaving this in place for now. TODO: fixme
+// eslint-disable-next-line
 function Receiver(configuration) {
   this.receiver = new StructuredHTTPReceiver(
     parserByMime,

--- a/lib/bindings/http/receiver_structured_0_3.js
+++ b/lib/bindings/http/receiver_structured_0_3.js
@@ -1,18 +1,13 @@
 const Constants = require("./constants.js");
-const Spec      = require("../../specs/spec_0_3.js");
-const JSONParser  = require("../../formats/json/parser.js");
+const Spec = require("../../specs/spec_0_3.js");
+const JSONParser = require("../../formats/json/parser.js");
 
 const StructuredHTTPReceiver = require("./receiver_structured.js");
-
-const {
-  isDefinedOrThrow,
-  isStringOrObjectOrThrow
-} = require("../../utils/fun.js");
 
 const jsonParserSpec = new JSONParser();
 
 const parserByMime = {};
-parserByMime[Constants.MIME_JSON]    = jsonParserSpec;
+parserByMime[Constants.MIME_JSON] = jsonParserSpec;
 parserByMime[Constants.MIME_CE_JSON] = jsonParserSpec;
 
 const allowedContentTypes = [];
@@ -20,24 +15,24 @@ allowedContentTypes.push(Constants.MIME_CE_JSON);
 
 const setterByAttribute = {};
 setterByAttribute[Constants.STRUCTURED_ATTRS_03.TYPE] = {
-  name : "type",
-  parser : (v) => v
+  name: "type",
+  parser: (v) => v
 };
 setterByAttribute[Constants.STRUCTURED_ATTRS_03.SPEC_VERSION] = {
-  name : "specversion",
-  parser : (v) => v
+  name: "specversion",
+  parser: (v) => v
 };
 setterByAttribute[Constants.STRUCTURED_ATTRS_03.SOURCE] = {
-  name : "source",
+  name: "source",
   parser: (v) => v
 };
 setterByAttribute[Constants.STRUCTURED_ATTRS_03.ID] = {
-  name : "id",
-  parser : (v) => v
+  name: "id",
+  parser: (v) => v
 };
 setterByAttribute[Constants.STRUCTURED_ATTRS_03.TIME] = {
-  name : "time",
-  parser : (v) => new Date(Date.parse(v))
+  name: "time",
+  parser: (v) => new Date(Date.parse(v))
 };
 setterByAttribute[Constants.STRUCTURED_ATTRS_03.SCHEMA_URL] = {
   name: "schemaurl",
@@ -60,6 +55,8 @@ setterByAttribute[Constants.STRUCTURED_ATTRS_03.DATA] = {
   parser: (v) => v
 };
 
+// Leaving this in place for now. TODO: fixme
+// eslint-disable-next-line
 function Receiver(configuration) {
   this.receiver = new StructuredHTTPReceiver(
     parserByMime,

--- a/lib/bindings/http/receiver_structured_1.js
+++ b/lib/bindings/http/receiver_structured_1.js
@@ -1,18 +1,13 @@
 const Constants = require("./constants.js");
-const Spec      = require("../../specs/spec_1.js");
-const JSONParser  = require("../../formats/json/parser.js");
+const Spec = require("../../specs/spec_1.js");
+const JSONParser = require("../../formats/json/parser.js");
 
 const StructuredHTTPReceiver = require("./receiver_structured.js");
-
-const {
-  isDefinedOrThrow,
-  isStringOrObjectOrThrow
-} = require("../../utils/fun.js");
 
 const jsonParserSpec = new JSONParser();
 
 const parserByMime = {};
-parserByMime[Constants.MIME_JSON]    = jsonParserSpec;
+parserByMime[Constants.MIME_JSON] = jsonParserSpec;
 parserByMime[Constants.MIME_CE_JSON] = jsonParserSpec;
 
 const allowedContentTypes = [];
@@ -20,24 +15,24 @@ allowedContentTypes.push(Constants.MIME_CE_JSON);
 
 const setterByAttribute = {};
 setterByAttribute[Constants.STRUCTURED_ATTRS_1.TYPE] = {
-  name : "type",
-  parser : (v) => v
+  name: "type",
+  parser: (v) => v
 };
 setterByAttribute[Constants.STRUCTURED_ATTRS_1.SPEC_VERSION] = {
-  name : "specversion",
-  parser : (v) => v
+  name: "specversion",
+  parser: (v) => v
 };
 setterByAttribute[Constants.STRUCTURED_ATTRS_1.SOURCE] = {
-  name : "source",
+  name: "source",
   parser: (v) => v
 };
 setterByAttribute[Constants.STRUCTURED_ATTRS_1.ID] = {
-  name : "id",
-  parser : (v) => v
+  name: "id",
+  parser: (v) => v
 };
 setterByAttribute[Constants.STRUCTURED_ATTRS_1.TIME] = {
-  name : "time",
-  parser : (v) => new Date(Date.parse(v))
+  name: "time",
+  parser: (v) => new Date(Date.parse(v))
 };
 setterByAttribute[Constants.STRUCTURED_ATTRS_1.DATA_SCHEMA] = {
   name: "dataschema",
@@ -60,6 +55,8 @@ setterByAttribute[Constants.STRUCTURED_ATTRS_1.DATA_BASE64] = {
   parser: (v) => v
 };
 
+// Leaving this in place for now. TODO: fixme
+// eslint-disable-next-line
 function Receiver(configuration) {
   this.receiver = new StructuredHTTPReceiver(
     parserByMime,

--- a/lib/bindings/http/unmarshaller.js
+++ b/lib/bindings/http/unmarshaller.js
@@ -1,16 +1,8 @@
-const StructuredReceiver = require("./receiver_structured_0_2.js");
-const BinaryReceiver     = require("./receiver_binary_0_2.js");
-
 const Constants = require("./constants.js");
-const Commons   = require("./commons.js");
+const Commons = require("./commons.js");
 
 const STRUCTURED = "structured";
 const BINARY = "binary";
-
-const receiverByBinding = {
-  structured : new StructuredReceiver(),
-  binary     : new BinaryReceiver(),
-};
 
 const allowedBinaryContentTypes = [];
 allowedBinaryContentTypes.push(Constants.MIME_JSON);
@@ -20,34 +12,37 @@ const allowedStructuredContentTypes = [];
 allowedStructuredContentTypes.push(Constants.MIME_CE_JSON);
 
 function validateArgs(payload, headers) {
-  if(!payload){
-    throw {message: "payload is null or undefined"};
+  if (!payload) {
+    throw new TypeError("payload is null or undefined");
   }
 
-  if(!headers){
-    throw {message: "headers is null or undefined"};
+  if (!headers) {
+    throw new TypeError("headers is null or undefined");
   }
 }
 
 // Is it binary or structured?
 function resolveBindingName(payload, headers) {
-
   const contentType =
     Commons.sanityContentType(headers[Constants.HEADER_CONTENT_TYPE]);
 
-  if(contentType.startsWith(Constants.MIME_CE)){
+  if (contentType.startsWith(Constants.MIME_CE)) {
     // Structured
-    if(allowedStructuredContentTypes.includes(contentType)){
+    if (allowedStructuredContentTypes.includes(contentType)) {
       return STRUCTURED;
     } else {
-      throw {message: "structured+type not allowed", errors: [contentType]};
+      const err = new TypeError("structured+type not allowed");
+      err.errors = [contentType];
+      throw err;
     }
   } else {
     // Binary
-    if(allowedBinaryContentTypes.includes(contentType)){
+    if (allowedBinaryContentTypes.includes(contentType)) {
       return BINARY;
     } else {
-      throw {message: "content type not allowed", errors : [contentType]};
+      const err = new TypeError("content type not allowed");
+      err.errors = [contentType];
+      throw err;
     }
   }
 }
@@ -64,18 +59,17 @@ Unmarshaller.prototype.unmarshall = function(payload, headers) {
       const sanityHeaders = Commons.sanityAndClone(headers);
 
       // Validation level 1
-      if(!sanityHeaders[Constants.HEADER_CONTENT_TYPE]){
-        throw {message: "content-type header not found"};
+      if (!sanityHeaders[Constants.HEADER_CONTENT_TYPE]) {
+        throw new TypeError("content-type header not found");
       }
 
       // Resolve the binding
       const bindingName = resolveBindingName(payload, sanityHeaders);
-
-      const cloudevent =
-        this.receiverByBinding[bindingName].parse(payload, sanityHeaders);
+      const cloudevent = this.receiverByBinding[bindingName]
+        .parse(payload, sanityHeaders);
 
       resolve(cloudevent);
-    }catch(e){
+    } catch (e) {
       reject(e);
     }
   });

--- a/lib/bindings/http/unmarshaller_0_2.js
+++ b/lib/bindings/http/unmarshaller_0_2.js
@@ -1,11 +1,11 @@
 const GenericUnmarshaller = require("./unmarshaller.js");
 
 const StructuredReceiver = require("./receiver_structured_0_2.js");
-const BinaryReceiver     = require("./receiver_binary_0_2.js");
+const BinaryReceiver = require("./receiver_binary_0_2.js");
 
 const RECEIVER_BY_BINDING = {
-  structured : new StructuredReceiver(),
-  binary     : new BinaryReceiver(),
+  structured: new StructuredReceiver(),
+  binary: new BinaryReceiver()
 };
 
 const Unmarshaller = function() {

--- a/lib/bindings/http/unmarshaller_0_3.js
+++ b/lib/bindings/http/unmarshaller_0_3.js
@@ -1,11 +1,11 @@
 const GenericUnmarshaller = require("./unmarshaller.js");
 
 const StructuredReceiver = require("./receiver_structured_0_3.js");
-const BinaryReceiver     = require("./receiver_binary_0_3.js");
+const BinaryReceiver = require("./receiver_binary_0_3.js");
 
 const RECEIVER_BY_BINDING = {
-  structured : new StructuredReceiver(),
-  binary     : new BinaryReceiver(),
+  structured: new StructuredReceiver(),
+  binary: new BinaryReceiver()
 };
 
 const Unmarshaller = function() {

--- a/lib/cloudevent.js
+++ b/lib/cloudevent.js
@@ -1,19 +1,19 @@
-const Spec01           = require("./specs/spec_0_1.js");
-const Spec02           = require("./specs/spec_0_2.js");
-const JSONFormatter01  = require("./formats/json/formatter.js");
+const Spec01 = require("./specs/spec_0_1.js");
+const Spec02 = require("./specs/spec_0_2.js");
+const JSONFormatter01 = require("./formats/json/formatter.js");
 const HTTPStructured01 = require("./bindings/http/emitter_structured_0_1.js");
 const HTTPStructured02 = require("./bindings/http/emitter_structured_0_2.js");
-const HTTPBinary01     = require("./bindings/http/emitter_binary_0_1.js");
-const {HTTPBinary02}   = require("./bindings/http/emitter_binary_0_2.js");
+const HTTPBinary01 = require("./bindings/http/emitter_binary_0_1.js");
+const { HTTPBinary02 } = require("./bindings/http/emitter_binary_0_2.js");
 
 /*
  * Class created using the Builder Design Pattern.
  *
  * https://en.wikipedia.org/wiki/Builder_pattern
  */
-function Cloudevent(_spec, _formatter){
-  this.spec      = (_spec) ? new _spec(Cloudevent) : new Spec01(Cloudevent);
-  this.formatter = (_formatter) ? _formatter : new JSONFormatter01();
+function Cloudevent(_spec, _formatter) {
+  this.spec = (_spec) ? new _spec(Cloudevent) : new Spec01(Cloudevent);
+  this.formatter = (_formatter) || new JSONFormatter01();
 
   // The map of extensions
   this.extensions = {};
@@ -22,7 +22,7 @@ function Cloudevent(_spec, _formatter){
 /*
  * To format the payload using the formatter
  */
-Cloudevent.prototype.format = function(){
+Cloudevent.prototype.format = function() {
   // Check the constraints
   this.spec.check();
 
@@ -33,11 +33,11 @@ Cloudevent.prototype.format = function(){
   return this.formatter.format(this.spec.payload);
 };
 
-Cloudevent.prototype.toString = function(){
+Cloudevent.prototype.toString = function() {
   return this.formatter.toString(this.spec.payload);
 };
 
-Cloudevent.prototype.type = function(type){
+Cloudevent.prototype.type = function(type) {
   this.spec.type(type);
   return this;
 };
@@ -54,16 +54,16 @@ Cloudevent.prototype.getSpecversion = function() {
   return this.spec.getSpecversion();
 };
 
-Cloudevent.prototype.source = function(_source){
+Cloudevent.prototype.source = function(_source) {
   this.spec.source(_source);
   return this;
 };
 
-Cloudevent.prototype.getSource = function(){
+Cloudevent.prototype.getSource = function() {
   return this.spec.getSource();
 };
 
-Cloudevent.prototype.id = function(_id){
+Cloudevent.prototype.id = function(_id) {
   this.spec.id(_id);
   return this;
 };
@@ -72,7 +72,7 @@ Cloudevent.prototype.getId = function() {
   return this.spec.getId();
 };
 
-Cloudevent.prototype.time = function(_time){
+Cloudevent.prototype.time = function(_time) {
   this.spec.time(_time);
   return this;
 };
@@ -90,7 +90,7 @@ Cloudevent.prototype.getSchemaurl = function() {
   return this.spec.getSchemaurl();
 };
 
-Cloudevent.prototype.contenttype = function(_contenttype){
+Cloudevent.prototype.contenttype = function(_contenttype) {
   this.spec.contenttype(_contenttype);
   return this;
 };
@@ -108,7 +108,7 @@ Cloudevent.prototype.getData = function() {
   return this.spec.getData();
 };
 
-Cloudevent.prototype.addExtension = function(key, value){
+Cloudevent.prototype.addExtension = function(key, value) {
   this.spec.addExtension(key, value);
 
   // Stores localy
@@ -121,29 +121,28 @@ Cloudevent.prototype.getExtensions = function() {
   return this.extensions;
 };
 
-
 /*
  * Export the specs
  */
 Cloudevent.specs = {
-  "0.1": Spec01,
-  "0.2": Spec02
+  0.1: Spec01,
+  0.2: Spec02
 };
 
 /*
  * Export the formats
  */
 Cloudevent.formats = {
-  "json"   : JSONFormatter01,
+  json: JSONFormatter01,
   "json0.1": JSONFormatter01
 };
 
 Cloudevent.bindings = {
-  "http-structured"    : HTTPStructured01,
-  "http-structured0.1" : HTTPStructured01,
-  "http-structured0.2" : HTTPStructured02,
-  "http-binary0.1"     : HTTPBinary01,
-  "http-binary0.2"     : HTTPBinary02
+  "http-structured": HTTPStructured01,
+  "http-structured0.1": HTTPStructured01,
+  "http-structured0.2": HTTPStructured02,
+  "http-binary0.1": HTTPBinary01,
+  "http-binary0.2": HTTPBinary02
 };
 
 module.exports = Cloudevent;

--- a/lib/formats/base64.js
+++ b/lib/formats/base64.js
@@ -5,7 +5,7 @@ function Parser(decorator) {
 
 Parser.prototype.parse = function(payload) {
   let toparse = payload;
-  if(this.decorator){
+  if (this.decorator) {
     toparse = this.decorator.parse(payload);
   }
 

--- a/lib/formats/json/formatter.js
+++ b/lib/formats/json/formatter.js
@@ -1,5 +1,5 @@
 
-function JSONFormatter(){
+function JSONFormatter() {
 
 }
 
@@ -7,11 +7,11 @@ function JSONFormatter(){
  * Every internal data structure is JSON by nature, so
  * no transformation is required
  */
-JSONFormatter.prototype.format = function(payload){
+JSONFormatter.prototype.format = function(payload) {
   return payload;
 };
 
-JSONFormatter.prototype.toString = function(payload){
+JSONFormatter.prototype.toString = function(payload) {
   return JSON.stringify(payload);
 };
 

--- a/lib/formats/json/parser.js
+++ b/lib/formats/json/parser.js
@@ -17,12 +17,9 @@ const nullOrIndefinedPayload =
 // Function
 const asJSON = (v) => (isString(v) ? JSON.parse(v) : v);
 
-/**
- * Level 0 of validation: is that string? is that JSON?
- */
+// Level 0 of validation: is that string? is that JSON?
 function validateAndParse(payload) {
-
-  const json =
+  var json =
     Array.of(payload)
       .filter((p) => isDefinedOrThrow(p, nullOrIndefinedPayload))
       .filter((p) => isStringOrObjectOrThrow(p, invalidPayloadTypeError))
@@ -32,25 +29,14 @@ function validateAndParse(payload) {
   return json;
 }
 
-/*
- * Level 1 of validation: is that follow a spec?
- */
-function validateSpec(payload, spec) {
-
-  // is that follow the spec?
-  spec.check(payload);
-
-  return payload;
-}
-
 JSONParser.prototype.parse = function(payload) {
   let toparse = payload;
 
-  if(this.decorator) {
+  if (this.decorator) {
     toparse = this.decorator.parse(payload);
   }
 
-  //is that string? is that JSON?
+  // is that string? is that JSON?
   const valid = validateAndParse(toparse);
 
   return valid;

--- a/lib/specs/spec_0_1.js
+++ b/lib/specs/spec_0_1.js
@@ -1,6 +1,6 @@
 const uuid = require("uuid/v4");
 
-function Spec01(_caller){
+function Spec01(_caller) {
   this.payload = {
     cloudEventsVersion: "0.1",
     eventID: uuid()
@@ -14,11 +14,11 @@ function Spec01(_caller){
   /*
    * Inject the method to set the version related to data attribute.
    */
-  this.caller.prototype.eventTypeVersion = function(_version){
+  this.caller.prototype.eventTypeVersion = function(_version) {
     return this.spec.eventTypeVersion(_version);
   };
 
-  this.caller.prototype.getEventTypeVersion = function(){
+  this.caller.prototype.getEventTypeVersion = function() {
     return this.spec.getEventTypeVersion();
   };
 }
@@ -29,94 +29,92 @@ function Spec01(_caller){
  * throw an error if do not pass.
  */
 Spec01.prototype.check = function() {
-
-  if(!this.payload["eventType"]){
-    throw {message: "'eventType' is invalid"};
+  if (!this.payload.eventType) {
+    throw new TypeError("'eventType' is invalid");
   }
-
 };
 
-Spec01.prototype.type = function(_type){
-  this.payload["eventType"] = _type;
+Spec01.prototype.type = function(_type) {
+  this.payload.eventType = _type;
   return this;
 };
 
-Spec01.prototype.getType = function(){
-  return this.payload["eventType"];
+Spec01.prototype.getType = function() {
+  return this.payload.eventType;
 };
 
 Spec01.prototype.getSpecversion = function() {
-  return this.payload["cloudEventsVersion"];
+  return this.payload.cloudEventsVersion;
 };
 
-Spec01.prototype.eventTypeVersion = function(version){
-  this.payload["eventTypeVersion"] = version;
+Spec01.prototype.eventTypeVersion = function(version) {
+  this.payload.eventTypeVersion = version;
   return this;
 };
 
 Spec01.prototype.getEventTypeVersion = function() {
-  return this.payload["eventTypeVersion"];
+  return this.payload.eventTypeVersion;
 };
 
-Spec01.prototype.source = function(_source){
-  this.payload["source"] = _source;
+Spec01.prototype.source = function(_source) {
+  this.payload.source = _source;
   return this;
 };
 
 Spec01.prototype.getSource = function() {
-  return this.payload["source"];
+  return this.payload.source;
 };
 
-Spec01.prototype.id = function(_id){
-  this.payload["eventID"] = _id;
+Spec01.prototype.id = function(_id) {
+  this.payload.eventID = _id;
   return this;
 };
 
 Spec01.prototype.getId = function() {
-  return this.payload["eventID"];
+  return this.payload.eventID;
 };
 
-Spec01.prototype.time = function(_time){
-  this.payload["eventTime"] = _time.toISOString();
+Spec01.prototype.time = function(_time) {
+  this.payload.eventTime = _time.toISOString();
   return this;
 };
 
 Spec01.prototype.getTime = function() {
-  return this.payload["eventTime"];
+  return this.payload.eventTime;
 };
 
-Spec01.prototype.schemaurl = function(_schemaurl){
-  this.payload["schemaURL"] = _schemaurl;
+Spec01.prototype.schemaurl = function(_schemaurl) {
+  this.payload.schemaURL = _schemaurl;
   return this;
 };
 
 Spec01.prototype.getSchemaurl = function() {
-  return this.payload["schemaURL"];
+  return this.payload.schemaURL;
 };
 
-Spec01.prototype.contenttype = function(_contenttype){
-  this.payload["contentType"] = _contenttype;
+Spec01.prototype.contenttype = function(_contenttype) {
+  this.payload.contentType = _contenttype;
   return this;
 };
 
 Spec01.prototype.getContenttype = function() {
-  return this.payload["contentType"];
+  return this.payload.contentType;
 };
 
-Spec01.prototype.data = function(_data){
-  this.payload["data"] = _data;
+Spec01.prototype.data = function(_data) {
+  this.payload.data = _data;
   return this;
 };
 
 Spec01.prototype.getData = function() {
-  return this.payload["data"];
+  return this.payload.data;
 };
 
-Spec01.prototype.addExtension = function(key, value){
-  if(!this.payload["extensions"]){
-    this.payload["extensions"] = {};
+Spec01.prototype.addExtension = function(key, value) {
+  if (!this.payload.extensions) {
+    this.payload.extensions = {};
   }
-  this.payload["extensions"][key] = value;
+  this.payload.extensions[key] = value;
   return this;
 };
 

--- a/lib/specs/spec_0_2.js
+++ b/lib/specs/spec_0_2.js
@@ -1,5 +1,5 @@
-var uuid  = require("uuid/v4");
-var Ajv   = require("ajv");
+const uuid = require("uuid/v4");
+const Ajv = require("ajv");
 
 // Reserved attributes names
 const reserved = {
@@ -16,12 +16,13 @@ const reserved = {
 const schema = require("../../ext/spec_0_2.json");
 
 const ajv = new Ajv({
-  extendRefs: true //  validate all keywords in the schemas with $ref (the default behaviour in versions before 5.0.0)
+  // validate all keywords in the schemas with $ref
+  extendRefs: true
 });
 
 const validate = ajv.compile(schema);
 
-function Spec02(){
+function Spec02() {
   this.payload = {
     specversion: "0.2",
     id: uuid()
@@ -31,95 +32,97 @@ function Spec02(){
 /*
  * Check the spec constraints
  */
-Spec02.prototype.check = function(ce){
+Spec02.prototype.check = function(ce) {
   var toCheck = ce;
-  if(!toCheck) {
+  if (!toCheck) {
     toCheck = this.payload;
   }
   const valid = validate(toCheck);
 
-  if(!valid) {
-    throw {message: "invalid payload", errors: validate.errors};
+  if (!valid) {
+    const err = new TypeError("invalid payload");
+    err.errors = validate.errors;
+    throw err;
   }
 };
 
-Spec02.prototype.type = function(_type){
-  this.payload["type"] = _type;
+Spec02.prototype.type = function(_type) {
+  this.payload.type = _type;
   return this;
 };
 
-Spec02.prototype.getType = function(){
-  return this.payload["type"];
+Spec02.prototype.getType = function() {
+  return this.payload.type;
 };
 
-Spec02.prototype.specversion = function(_specversion){
+Spec02.prototype.specversion = function() {
   // does not set! This is right
   return this;
 };
 
 Spec02.prototype.getSpecversion = function() {
-  return this.payload["specversion"];
+  return this.payload.specversion;
 };
 
-Spec02.prototype.source = function(_source){
-  this.payload["source"] = _source;
+Spec02.prototype.source = function(_source) {
+  this.payload.source = _source;
   return this;
 };
 
 Spec02.prototype.getSource = function() {
-  return this.payload["source"];
+  return this.payload.source;
 };
 
-Spec02.prototype.id = function(_id){
-  this.payload["id"] = _id;
+Spec02.prototype.id = function(_id) {
+  this.payload.id = _id;
   return this;
 };
 
 Spec02.prototype.getId = function() {
-  return this.payload["id"];
+  return this.payload.id;
 };
 
-Spec02.prototype.time = function(_time){
-  this.payload["time"] = _time.toISOString();
+Spec02.prototype.time = function(_time) {
+  this.payload.time = _time.toISOString();
   return this;
 };
 
 Spec02.prototype.getTime = function() {
-  return this.payload["time"];
+  return this.payload.time;
 };
 
-Spec02.prototype.schemaurl = function(_schemaurl){
-  this.payload["schemaurl"] = _schemaurl;
+Spec02.prototype.schemaurl = function(_schemaurl) {
+  this.payload.schemaurl = _schemaurl;
   return this;
 };
 
 Spec02.prototype.getSchemaurl = function() {
-  return this.payload["schemaurl"];
+  return this.payload.schemaurl;
 };
 
-Spec02.prototype.contenttype = function(_contenttype){
-  this.payload["contenttype"] = _contenttype;
+Spec02.prototype.contenttype = function(_contenttype) {
+  this.payload.contenttype = _contenttype;
   return this;
 };
 
 Spec02.prototype.getContenttype = function() {
-  return this.payload["contenttype"];
+  return this.payload.contenttype;
 };
 
-Spec02.prototype.data = function(_data){
-  this.payload["data"] = _data;
+Spec02.prototype.data = function(_data) {
+  this.payload.data = _data;
   return this;
 };
 
 Spec02.prototype.getData = function() {
-  return this.payload["data"];
+  return this.payload.data;
 };
 
-Spec02.prototype.addExtension = function(key, value){
-  if(!reserved.hasOwnProperty(key)){
+Spec02.prototype.addExtension = function(key, value) {
+  if (!Object.prototype.hasOwnProperty.call(reserved, key)) {
     this.payload[key] = value;
   } else {
-    throw {message: "Reserved attribute name: '" + key + "'"};
+    throw new TypeError(`Reserved attribute name: '${key}'`);
   }
   return this;
 };

--- a/lib/specs/spec_0_3.js
+++ b/lib/specs/spec_0_3.js
@@ -1,8 +1,7 @@
-const uuid  = require("uuid/v4");
-const Ajv   = require("ajv");
+const uuid = require("uuid/v4");
+const Ajv = require("ajv");
 
 const {
-  equalsOrThrow,
   isBase64,
   clone,
   asData
@@ -17,13 +16,13 @@ const RESERVED_ATTRIBUTES = {
   schemaurl: "schemaurl",
   datacontentencoding: "datacontentencoding",
   datacontenttype: "datacontenttype",
-  subject : "subject",
+  subject: "subject",
   data: "data"
 };
 
 const SUPPORTED_CONTENT_ENCODING = {};
-SUPPORTED_CONTENT_ENCODING["base64"] = {
-  check : (data) => isBase64(data)
+SUPPORTED_CONTENT_ENCODING.base64 = {
+  check: (data) => isBase64(data)
 };
 
 const schema = require("../../ext/spec_0_3.json");
@@ -34,13 +33,13 @@ const ajv = new Ajv({
 
 const isValidAgainstSchema = ajv.compile(schema);
 
-function Spec03(_caller){
+function Spec03(_caller) {
   this.payload = {
     specversion: "0.3",
     id: uuid()
   };
 
-  if(!_caller){
+  if (!_caller) {
     _caller = require("../cloudevent.js");
   }
 
@@ -52,178 +51,184 @@ function Spec03(_caller){
   /*
    * Inject compatibility methods
    */
-  this.caller.prototype.dataContentEncoding = function(encoding){
+  this.caller.prototype.dataContentEncoding = function(encoding) {
     this.spec.dataContentEncoding(encoding);
     return this;
   };
-  this.caller.prototype.getDataContentEncoding = function(){
-   return this.spec.getDataContentEncoding();
+  this.caller.prototype.getDataContentEncoding = function() {
+    return this.spec.getDataContentEncoding();
   };
 
-  this.caller.prototype.dataContentType = function(contentType){
+  this.caller.prototype.dataContentType = function(contentType) {
     this.spec.dataContentType(contentType);
     return this;
   };
-  this.caller.prototype.getDataContentType = function(){
-   return this.spec.getDataContentType();
+  this.caller.prototype.getDataContentType = function() {
+    return this.spec.getDataContentType();
   };
 
-  this.caller.prototype.subject = function(_subject){
+  this.caller.prototype.subject = function(_subject) {
     this.spec.subject(_subject);
     return this;
   };
-  this.caller.prototype.getSubject = function(){
-   return this.spec.getSubject();
+  this.caller.prototype.getSubject = function() {
+    return this.spec.getSubject();
   };
 }
 
 /*
  * Check the spec constraints
  */
-Spec03.prototype.check = function(ce){
+Spec03.prototype.check = function(ce) {
   const toCheck = (!ce ? this.payload : ce);
 
-  if(!isValidAgainstSchema(toCheck)) {
-    throw {message: "invalid payload", errors: isValidAgainstSchema.errors};
+  if (!isValidAgainstSchema(toCheck)) {
+    const err = new TypeError("invalid payload");
+    err.errors = isValidAgainstSchema.errors;
+    throw err;
   }
 
   Array.of(toCheck)
-    .filter((tc) => tc["datacontentencoding"])
-    .map((tc) => tc["datacontentencoding"].toLocaleLowerCase("en-US"))
+    .filter((tc) => tc.datacontentencoding)
+    .map((tc) => tc.datacontentencoding.toLocaleLowerCase("en-US"))
     .filter((dce) => !Object.keys(SUPPORTED_CONTENT_ENCODING).includes(dce))
     .forEach((dce) => {
-      throw {message: "invalid payload", errors: [
-        "Unsupported content encoding: " + dce
-      ]};
+      const err = new TypeError("invalid payload");
+      err.errors = [
+        `Unsupported content encoding: ${dce}`
+      ];
+      throw err;
     });
 
   Array.of(toCheck)
-    .filter((tc) => tc["datacontentencoding"])
+    .filter((tc) => tc.datacontentencoding)
     .filter((tc) => (typeof tc.data) === "string")
     .map((tc) => {
-      let newtc = clone(tc);
+      const newtc = clone(tc);
       newtc.datacontentencoding =
         newtc.datacontentencoding.toLocaleLowerCase("en-US");
 
       return newtc;
     })
     .filter((tc) => Object.keys(SUPPORTED_CONTENT_ENCODING)
-                            .includes(tc.datacontentencoding))
+      .includes(tc.datacontentencoding))
     .filter((tc) => !SUPPORTED_CONTENT_ENCODING[tc.datacontentencoding]
-                        .check(tc.data))
+      .check(tc.data))
     .forEach((tc) => {
-      throw {message: "invalid payload", errors: [
-        "Invalid content encoding of data: " + tc.data
-      ]};
+      const err = new TypeError("invalid payload");
+      err.errors = [
+        `Invalid content encoding of data: ${tc.data}`
+      ];
+      throw err;
     });
 };
 
-Spec03.prototype.id = function(_id){
-  this.payload["id"] = _id;
+Spec03.prototype.id = function(_id) {
+  this.payload.id = _id;
   return this;
 };
 
 Spec03.prototype.getId = function() {
-  return this.payload["id"];
+  return this.payload.id;
 };
 
-Spec03.prototype.source = function(_source){
-  this.payload["source"] = _source;
+Spec03.prototype.source = function(_source) {
+  this.payload.source = _source;
   return this;
 };
 
 Spec03.prototype.getSource = function() {
-  return this.payload["source"];
+  return this.payload.source;
 };
 
-Spec03.prototype.specversion = function(_specversion){
+Spec03.prototype.specversion = function() {
   // does not set! This is right
   return this;
 };
 
 Spec03.prototype.getSpecversion = function() {
-  return this.payload["specversion"];
+  return this.payload.specversion;
 };
 
-Spec03.prototype.type = function(_type){
-  this.payload["type"] = _type;
+Spec03.prototype.type = function(_type) {
+  this.payload.type = _type;
   return this;
 };
 
-Spec03.prototype.getType = function(){
-  return this.payload["type"];
+Spec03.prototype.getType = function() {
+  return this.payload.type;
 };
 
 Spec03.prototype.dataContentEncoding = function(encoding) {
-  this.payload["datacontentencoding"] = encoding;
+  this.payload.datacontentencoding = encoding;
   return this;
 };
 
 Spec03.prototype.getDataContentEncoding = function() {
-  return this.payload["datacontentencoding"];
+  return this.payload.datacontentencoding;
 };
 
 // maps to datacontenttype
-Spec03.prototype.contenttype = function(_contenttype){
-  this.payload["datacontenttype"] = _contenttype;
+Spec03.prototype.contenttype = function(_contenttype) {
+  this.payload.datacontenttype = _contenttype;
   return this;
 };
 Spec03.prototype.getContenttype = function() {
-  return this.payload["datacontenttype"];
+  return this.payload.datacontenttype;
 };
 
-Spec03.prototype.dataContentType = function(_contenttype){
-  this.payload["datacontenttype"] = _contenttype;
+Spec03.prototype.dataContentType = function(_contenttype) {
+  this.payload.datacontenttype = _contenttype;
   return this;
 };
 Spec03.prototype.getDataContentType = function() {
-  return this.payload["datacontenttype"];
+  return this.payload.datacontenttype;
 };
 
-Spec03.prototype.schemaurl = function(_schemaurl){
-  this.payload["schemaurl"] = _schemaurl;
+Spec03.prototype.schemaurl = function(_schemaurl) {
+  this.payload.schemaurl = _schemaurl;
   return this;
 };
 Spec03.prototype.getSchemaurl = function() {
-  return this.payload["schemaurl"];
+  return this.payload.schemaurl;
 };
 
-Spec03.prototype.subject = function(_subject){
-  this.payload["subject"] = _subject;
+Spec03.prototype.subject = function(_subject) {
+  this.payload.subject = _subject;
   return this;
 };
 Spec03.prototype.getSubject = function() {
-  return this.payload["subject"];
+  return this.payload.subject;
 };
 
-Spec03.prototype.time = function(_time){
-  this.payload["time"] = _time.toISOString();
+Spec03.prototype.time = function(_time) {
+  this.payload.time = _time.toISOString();
   return this;
 };
 Spec03.prototype.getTime = function() {
-  return this.payload["time"];
+  return this.payload.time;
 };
 
-Spec03.prototype.data = function(_data){
-  this.payload["data"] = _data;
+Spec03.prototype.data = function(_data) {
+  this.payload.data = _data;
   return this;
 };
 Spec03.prototype.getData = function() {
-  let dct = this.payload["datacontenttype"];
-  let dce = this.payload["datacontentencoding"];
+  const dct = this.payload.datacontenttype;
+  const dce = this.payload.datacontentencoding;
 
-  if(dct && !dce){
-    this.payload["data"] = asData(this.payload["data"], dct);
+  if (dct && !dce) {
+    this.payload.data = asData(this.payload.data, dct);
   }
 
-  return this.payload["data"];
+  return this.payload.data;
 };
 
-Spec03.prototype.addExtension = function(key, value){
-  if(!RESERVED_ATTRIBUTES.hasOwnProperty(key)){
+Spec03.prototype.addExtension = function(key, value) {
+  if (!Object.prototype.hasOwnProperty.call(RESERVED_ATTRIBUTES, key)) {
     this.payload[key] = value;
   } else {
-    throw {message: "Reserved attribute name: '" + key + "'"};
+    throw new TypeError(`Reserved attribute name: '${key}'`);
   }
   return this;
 };

--- a/lib/specs/spec_1.js
+++ b/lib/specs/spec_1.js
@@ -1,5 +1,5 @@
-const uuid  = require("uuid/v4");
-const Ajv   = require("ajv");
+const uuid = require("uuid/v4");
+const Ajv = require("ajv");
 
 const {
   asData,
@@ -22,7 +22,7 @@ const RESERVED_ATTRIBUTES = {
   time: "time",
   dataschema: "schemaurl",
   datacontenttype: "datacontenttype",
-  subject : "subject",
+  subject: "subject",
   data: "data",
   data_base64: "data_base64"
 };
@@ -41,7 +41,7 @@ function Spec1(_caller) {
     id: uuid()
   };
 
-  if(!_caller){
+  if (!_caller) {
     _caller = require("../cloudevent.js");
   }
 
@@ -51,7 +51,7 @@ function Spec1(_caller) {
   this.caller = _caller;
 
   // dataschema attribute
-  this.caller.prototype.dataschema = function(dataschema){
+  this.caller.prototype.dataschema = function(dataschema) {
     this.spec.dataschema(dataschema);
     return this;
   };
@@ -60,40 +60,41 @@ function Spec1(_caller) {
   };
 
   // datacontenttype attribute
-  this.caller.prototype.dataContentType = function(contentType){
+  this.caller.prototype.dataContentType = function(contentType) {
     this.spec.dataContentType(contentType);
     return this;
   };
-  this.caller.prototype.getDataContentType = function(){
-   return this.spec.getDataContentType();
+  this.caller.prototype.getDataContentType = function() {
+    return this.spec.getDataContentType();
   };
 
   // subject attribute
-  this.caller.prototype.subject = function(_subject){
+  this.caller.prototype.subject = function(_subject) {
     this.spec.subject(_subject);
     return this;
   };
-  this.caller.prototype.getSubject = function(){
-   return this.spec.getSubject();
+  this.caller.prototype.getSubject = function() {
+    return this.spec.getSubject();
   };
 
   // format() method override
-  this.caller.prototype.format = function(){
+  this.caller.prototype.format = function() {
     // Check the constraints
     this.spec.check();
 
     // Check before getData() call
-    let isbin = isBinary(this.spec.payload[RESERVED_ATTRIBUTES.data]);
+    const isbin = isBinary(this.spec.payload[RESERVED_ATTRIBUTES.data]);
 
     // May be used, if isbin==true
-    let payload = clone(this.spec.payload);
+    const payload = clone(this.spec.payload);
 
     // To run asData()
     this.getData();
 
     // Handle when is binary, creating the data_base64
-    if(isbin) {
-      payload[RESERVED_ATTRIBUTES.data_base64] = this.spec.payload[RESERVED_ATTRIBUTES.data];
+    if (isbin) {
+      payload[RESERVED_ATTRIBUTES.data_base64] =
+        this.spec.payload[RESERVED_ATTRIBUTES.data];
       delete payload[RESERVED_ATTRIBUTES.data];
 
       return this.formatter.format(payload);
@@ -107,105 +108,107 @@ function Spec1(_caller) {
 /*
  * Check the spec constraints
  */
-Spec1.prototype.check = function(ce){
-  const toCheck = (!ce ? this.payload : ce);
+Spec1.prototype.check = function(ce) {
+  var toCheck = (!ce ? this.payload : ce);
 
-  if(!isValidAgainstSchema(toCheck)) {
-    throw {message: "invalid payload", errors: isValidAgainstSchema.errors};
+  if (!isValidAgainstSchema(toCheck)) {
+    const err = new TypeError("invalid payload");
+    err.errors = isValidAgainstSchema.errors;
+    throw err;
   }
 };
 
-Spec1.prototype.id = function(_id){
-  this.payload["id"] = _id;
+Spec1.prototype.id = function(_id) {
+  this.payload.id = _id;
   return this;
 };
 
 Spec1.prototype.getId = function() {
-  return this.payload["id"];
+  return this.payload.id;
 };
 
-Spec1.prototype.source = function(_source){
-  this.payload["source"] = _source;
+Spec1.prototype.source = function(_source) {
+  this.payload.source = _source;
   return this;
 };
 
 Spec1.prototype.getSource = function() {
-  return this.payload["source"];
+  return this.payload.source;
 };
 
-Spec1.prototype.specversion = function(_specversion){
+Spec1.prototype.specversion = function() {
   // does not set! This is right
   return this;
 };
 
 Spec1.prototype.getSpecversion = function() {
-  return this.payload["specversion"];
+  return this.payload.specversion;
 };
 
-Spec1.prototype.type = function(_type){
-  this.payload["type"] = _type;
+Spec1.prototype.type = function(_type) {
+  this.payload.type = _type;
   return this;
 };
 
-Spec1.prototype.getType = function(){
-  return this.payload["type"];
+Spec1.prototype.getType = function() {
+  return this.payload.type;
 };
 
-Spec1.prototype.dataContentType = function(_contenttype){
-  this.payload["datacontenttype"] = _contenttype;
+Spec1.prototype.dataContentType = function(_contenttype) {
+  this.payload.datacontenttype = _contenttype;
   return this;
 };
 Spec1.prototype.getDataContentType = function() {
-  return this.payload["datacontenttype"];
+  return this.payload.datacontenttype;
 };
 
-Spec1.prototype.dataschema = function(_schema){
-  this.payload["dataschema"] = _schema;
+Spec1.prototype.dataschema = function(_schema) {
+  this.payload.dataschema = _schema;
   return this;
 };
 Spec1.prototype.getDataschema = function() {
-  return this.payload["dataschema"];
+  return this.payload.dataschema;
 };
 
-Spec1.prototype.subject = function(_subject){
-  this.payload["subject"] = _subject;
+Spec1.prototype.subject = function(_subject) {
+  this.payload.subject = _subject;
   return this;
 };
 Spec1.prototype.getSubject = function() {
-  return this.payload["subject"];
+  return this.payload.subject;
 };
 
-Spec1.prototype.time = function(_time){
-  this.payload["time"] = _time.toISOString();
+Spec1.prototype.time = function(_time) {
+  this.payload.time = _time.toISOString();
   return this;
 };
 Spec1.prototype.getTime = function() {
-  return this.payload["time"];
+  return this.payload.time;
 };
 
-Spec1.prototype.data = function(_data){
-  this.payload["data"] = _data;
+Spec1.prototype.data = function(_data) {
+  this.payload.data = _data;
   return this;
 };
 Spec1.prototype.getData = function() {
-  let dct = this.payload["datacontenttype"];
+  const dct = this.payload.datacontenttype;
 
-  if(dct){
-    this.payload["data"] = asData(this.payload["data"], dct);
+  if (dct) {
+    this.payload.data = asData(this.payload.data, dct);
   }
 
-  return this.payload["data"];
+  return this.payload.data;
 };
 
-Spec1.prototype.addExtension = function(key, value){
-  if(!RESERVED_ATTRIBUTES.hasOwnProperty(key)){
-    if(isValidType(value)){
+Spec1.prototype.addExtension = function(key, value) {
+  if (!Object.prototype.hasOwnProperty.call(RESERVED_ATTRIBUTES, key)) {
+    if (isValidType(value)) {
       this.payload[key] = value;
     } else {
-      throw {message: "Invalid type of extension value"};
+      throw new TypeError("Invalid type of extension value");
     }
   } else {
-    throw {message: "Reserved attribute name: '" + key + "'"};
+    throw new TypeError(`Reserved attribute name: '${key}'`);
   }
   return this;
 };

--- a/lib/utils/fun.js
+++ b/lib/utils/fun.js
@@ -1,7 +1,7 @@
 // Functional approach
 const isString = (v) => (typeof v) === "string";
 const isObject = (v) => (typeof v) === "object";
-const isDefined = (v) => v && (typeof v) != "undefined";
+const isDefined = (v) => v && (typeof v) !== "undefined";
 
 const isBoolean = (v) => (typeof v) === "boolean";
 const isInteger = (v) => Number.isInteger(v);
@@ -11,24 +11,24 @@ const isBinary = (v) => (v instanceof Uint32Array);
 const isStringOrThrow = (v, t) =>
   (isString(v)
     ? true
-    : (() => {throw t;})());
+    : (() => { throw t; })());
 
 const isDefinedOrThrow = (v, t) =>
   (isDefined(v)
-    ?  () => true
-    : (() => {throw t;})());
+    ? () => true
+    : (() => { throw t; })());
 
 const isStringOrObjectOrThrow = (v, t) =>
-        (isString(v)
-          ? true
-          : isObject(v)
-            ? true
-            : (() => {throw t;})());
+  (isString(v)
+    ? true
+    : isObject(v)
+      ? true
+      : (() => { throw t; })());
 
 const equalsOrThrow = (v1, v2, t) =>
   (v1 === v2
     ? true
-    : (() => {throw t;})());
+    : (() => { throw t; })());
 
 const isBase64 = (value) =>
   Buffer.from(value, "base64").toString("base64") === value;
@@ -41,7 +41,7 @@ const asBuffer = (value) =>
     ? Buffer.from(value)
     : isBuffer(value)
       ? value
-      : (() => {throw {message: "is not buffer or a valid binary"};})();
+      : (() => { throw new TypeError("is not buffer or a valid binary"); })();
 
 const asBase64 = (value) =>
   asBuffer(value).toString("base64");
@@ -56,7 +56,9 @@ const asData = (data, contentType) => {
   let result = data;
 
   // pattern matching alike
-  result = isString(result) && !isBase64(result) && isJsonContentType(contentType)
+  result = isString(result) &&
+    !isBase64(result) &&
+    isJsonContentType(contentType)
     ? JSON.parse(result)
     : result;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -309,6 +309,18 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "acorn": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+      "dev": true
+    },
     "aggregate-error": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
@@ -335,6 +347,23 @@
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
       "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
       "dev": true
+    },
+    "ansi-escapes": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.11.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "dev": true
+        }
+      }
     },
     "ansi-regex": {
       "version": "3.0.0",
@@ -385,10 +414,37 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "array-includes": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
+      "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0",
+        "is-string": "^1.0.5"
+      }
+    },
+    "array.prototype.flat": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
+      "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      }
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
     "axios": {
@@ -448,6 +504,12 @@
         "write-file-atomic": "^3.0.0"
       }
     },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -490,6 +552,12 @@
         }
       }
     },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -516,6 +584,21 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
     },
     "cliui": {
@@ -584,6 +667,12 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true
+    },
     "convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -623,6 +712,12 @@
         "ms": "2.0.0"
       }
     },
+    "debug-log": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+      "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+      "dev": true
+    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -637,6 +732,12 @@
       "requires": {
         "type-detect": "^4.0.0"
       }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
     },
     "default-require-extensions": {
       "version": "3.0.0",
@@ -656,17 +757,50 @@
         "object-keys": "^1.0.12"
       }
     },
+    "deglob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/deglob/-/deglob-4.0.1.tgz",
+      "integrity": "sha512-/g+RDZ7yf2HvoW+E5Cy+K94YhgcFgr6C8LuHZD1O5HoNPkf3KY6RfXJ0DBGlB/NkLi5gml+G9zqRzk9S0mHZCg==",
+      "dev": true,
+      "requires": {
+        "find-root": "^1.0.0",
+        "glob": "^7.0.5",
+        "ignore": "^5.0.0",
+        "pkg-config": "^1.1.0",
+        "run-parallel": "^1.1.2",
+        "uniq": "^1.0.1"
+      }
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
+    "doctrine": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+      "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "isarray": "^1.0.0"
+      }
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
     },
     "es-abstract": {
       "version": "1.17.5",
@@ -710,11 +844,475 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "eslint": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.4.3",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.2",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^7.0.0",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.14",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.3",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true
+            }
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "doctrine": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+          "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "eslint-utils": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+          "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true
+        },
+        "regexpp": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+          "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
+          "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-config-standard": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
+      "integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
+      "dev": true
+    },
+    "eslint-config-standard-jsx": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-8.1.0.tgz",
+      "integrity": "sha512-ULVC8qH8qCqbU792ZOO6DaiaZyHNS/5CZt3hKqHkEhVlhPEPN3nfBqqxJCyp59XrjIBZPu1chMYe9T2DXZ7TMw==",
+      "dev": true
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
+      "integrity": "sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "resolve": "^1.13.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
+      "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "pkg-dir": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-es": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.0.tgz",
+      "integrity": "sha512-6/Jb/J/ZvSebydwbBJO1R9E5ky7YeElfK56Veh7e4QGFHCXoIXGH9HhVz+ibJLM3XJ1XjP+T7rKBLUa/Y7eIng==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.20.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.2.tgz",
+      "integrity": "sha512-FObidqpXrR8OnCh4iNsxy+WACztJLXAHBO5hK79T1Hc77PgQZkyDGA5Ag9xAvRpglvLNxhH/zSmZ70/pZ31dHg==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "array.prototype.flat": "^1.2.1",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "^0.3.2",
+        "eslint-module-utils": "^2.4.1",
+        "has": "^1.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.0",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.12.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-node": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
+      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-es": "^3.0.0",
+        "eslint-utils": "^2.0.0",
+        "ignore": "^5.1.1",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.10.1",
+        "semver": "^6.1.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-promise": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
+      "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
+      "dev": true
+    },
+    "eslint-plugin-react": {
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
+      "integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "doctrine": "^2.1.0",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.1.0",
+        "object.entries": "^1.1.0",
+        "object.fromentries": "^2.0.0",
+        "object.values": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "resolve": "^1.10.1"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        }
+      }
+    },
+    "eslint-plugin-standard": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz",
+      "integrity": "sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ==",
+      "dev": true
+    },
+    "eslint-scope": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+      "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "dev": true
+    },
+    "espree": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
+    },
+    "esquery": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
+          "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
+          "dev": true
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
     },
     "fast-deep-equal": {
       "version": "3.1.1",
@@ -725,6 +1323,30 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
     },
     "fill-range": {
       "version": "7.0.1",
@@ -746,6 +1368,12 @@
         "pkg-dir": "^4.1.0"
       }
     },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "dev": true
+    },
     "find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -763,6 +1391,34 @@
       "requires": {
         "is-buffer": "~2.0.3"
       }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "flatted": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "dev": true
     },
     "follow-redirects": {
       "version": "1.5.10",
@@ -807,6 +1463,12 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
     "gensync": {
       "version": "1.0.0-beta.1",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
@@ -823,6 +1485,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
       "dev": true
     },
     "glob": {
@@ -903,11 +1571,50 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "hosted-git-info": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "dev": true
+    },
     "html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+      "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
+      }
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -935,6 +1642,123 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^3.0.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.5.3",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-binary-path": {
@@ -991,6 +1815,12 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
     "is-regex": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
@@ -1004,6 +1834,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
       "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "dev": true
+    },
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
       "dev": true
     },
     "is-symbol": {
@@ -1025,6 +1861,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isexe": {
@@ -1180,10 +2022,22 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -1198,6 +2052,46 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
+      }
+    },
+    "jsx-ast-utils": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz",
+      "integrity": "sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "object.assign": "^4.1.0"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "load-json-file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
       }
     },
     "locate-path": {
@@ -1231,6 +2125,15 @@
         "chalk": "^2.4.2"
       }
     },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
     "make-dir": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
@@ -1247,6 +2150,12 @@
           "dev": true
         }
       }
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1326,6 +2235,24 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
     "nock": {
       "version": "12.0.3",
       "resolved": "https://registry.npmjs.org/nock/-/nock-12.0.3.tgz",
@@ -1372,6 +2299,18 @@
       "dev": true,
       "requires": {
         "process-on-spawn": "^1.0.0"
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -1580,6 +2519,12 @@
         }
       }
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
@@ -1604,6 +2549,30 @@
         "object-keys": "^1.0.11"
       }
     },
+    "object.entries": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
+      "integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.2.tgz",
+      "integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
     "object.getownpropertydescriptors": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
@@ -1614,6 +2583,18 @@
         "es-abstract": "^1.17.0-next.1"
       }
     },
+    "object.values": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
+      "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1622,6 +2603,35 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "onetime": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "p-limit": {
       "version": "2.2.2",
@@ -1668,6 +2678,24 @@
         "release-zalgo": "^1.0.0"
       }
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -1692,6 +2720,15 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "path-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "dev": true,
+      "requires": {
+        "pify": "^2.0.0"
+      }
+    },
     "pathval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
@@ -1703,6 +2740,76 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pkg-conf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0",
+        "load-json-file": "^5.2.0"
+      },
+      "dependencies": {
+        "load-json-file": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+          "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.15",
+            "parse-json": "^4.0.0",
+            "pify": "^4.0.1",
+            "strip-bom": "^3.0.0",
+            "type-fest": "^0.3.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+          "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+          "dev": true
+        }
+      }
+    },
+    "pkg-config": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
+      "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
+      "dev": true,
+      "requires": {
+        "debug-log": "^1.0.0",
+        "find-root": "^1.0.0",
+        "xtend": "^4.0.1"
+      }
     },
     "pkg-dir": {
       "version": "4.2.0",
@@ -1749,6 +2856,12 @@
         }
       }
     },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
     "process-on-spawn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
@@ -1756,6 +2869,23 @@
       "dev": true,
       "requires": {
         "fromentries": "^1.2.0"
+      }
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
       }
     },
     "propagate": {
@@ -1769,6 +2899,78 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
+    },
+    "read-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        }
+      }
+    },
     "readdirp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
@@ -1777,6 +2979,12 @@
       "requires": {
         "picomatch": "^2.0.4"
       }
+    },
+    "regexpp": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "dev": true
     },
     "release-zalgo": {
       "version": "1.0.0",
@@ -1814,6 +3022,16 @@
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
     },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "requires": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -1823,10 +3041,40 @@
         "glob": "^7.1.3"
       }
     },
+    "run-async": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
+      "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "dev": true
+    },
+    "rxjs": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
+      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
     "semver": {
@@ -1862,6 +3110,17 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -1893,11 +3152,157 @@
         }
       }
     },
+    "spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "dev": true
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "standard": {
+      "version": "14.3.3",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-14.3.3.tgz",
+      "integrity": "sha512-HBEAD5eVXrr2o/KZ3kU8Wwaxw90wzoq4dOQe6vlRnPoQ6stn4LCLRLBBDp0CjH/aOTL9bDZJbRUOZcBaBnNJ0A==",
+      "dev": true,
+      "requires": {
+        "eslint": "~6.8.0",
+        "eslint-config-standard": "14.1.0",
+        "eslint-config-standard-jsx": "8.1.0",
+        "eslint-plugin-import": "~2.18.0",
+        "eslint-plugin-node": "~10.0.0",
+        "eslint-plugin-promise": "~4.2.1",
+        "eslint-plugin-react": "~7.14.2",
+        "eslint-plugin-standard": "~4.0.0",
+        "standard-engine": "^12.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "eslint-config-standard": {
+          "version": "14.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.0.tgz",
+          "integrity": "sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA==",
+          "dev": true
+        },
+        "eslint-plugin-es": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-2.0.0.tgz",
+          "integrity": "sha512-f6fceVtg27BR02EYnBhgWLFQfK6bN4Ll0nQFrBHOlCsAyxeZkn0NHns5O0YZOPrV1B3ramd6cgFwaoFLcSkwEQ==",
+          "dev": true,
+          "requires": {
+            "eslint-utils": "^1.4.2",
+            "regexpp": "^3.0.0"
+          }
+        },
+        "eslint-plugin-import": {
+          "version": "2.18.2",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
+          "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
+          "dev": true,
+          "requires": {
+            "array-includes": "^3.0.3",
+            "contains-path": "^0.1.0",
+            "debug": "^2.6.9",
+            "doctrine": "1.5.0",
+            "eslint-import-resolver-node": "^0.3.2",
+            "eslint-module-utils": "^2.4.0",
+            "has": "^1.0.3",
+            "minimatch": "^3.0.4",
+            "object.values": "^1.1.0",
+            "read-pkg-up": "^2.0.0",
+            "resolve": "^1.11.0"
+          }
+        },
+        "eslint-plugin-node": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-10.0.0.tgz",
+          "integrity": "sha512-1CSyM/QCjs6PXaT18+zuAXsjXGIGo5Rw630rSKwokSs2jrYURQc4R5JZpoanNCqwNmepg+0eZ9L7YiRUJb8jiQ==",
+          "dev": true,
+          "requires": {
+            "eslint-plugin-es": "^2.0.0",
+            "eslint-utils": "^1.4.2",
+            "ignore": "^5.1.1",
+            "minimatch": "^3.0.4",
+            "resolve": "^1.10.1",
+            "semver": "^6.1.0"
+          }
+        },
+        "eslint-utils": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+          "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "standard-engine": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-12.0.0.tgz",
+      "integrity": "sha512-gJIIRb0LpL7AHyGbN9+hJ4UJns37lxmNTnMGRLC8CFrzQ+oB/K60IQjKNgPBCB2VP60Ypm6f8DFXvhVWdBOO+g==",
+      "dev": true,
+      "requires": {
+        "deglob": "^4.0.0",
+        "get-stdin": "^7.0.0",
+        "minimist": "^1.1.0",
+        "pkg-conf": "^3.1.0"
+      }
+    },
+    "standardx": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/standardx/-/standardx-5.0.0.tgz",
+      "integrity": "sha512-dWbhU91EqwwWTED224B4X0h1q01Tv2wIv30mFz4NOQ+JMEJKtCrBOUEgMpBIynSFm6MDJYr+H7xUPVMYjGd8HA==",
+      "dev": true,
+      "requires": {
+        "standard": "^14.0.0",
+        "standard-engine": "^12.0.0"
+      }
     },
     "string-width": {
       "version": "2.1.1",
@@ -1981,6 +3386,46 @@
         "has-flag": "^3.0.0"
       }
     },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
     "test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -2008,6 +3453,27 @@
         }
       }
     },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -2021,6 +3487,21 @@
       "dev": true,
       "requires": {
         "is-number": "^7.0.0"
+      }
+    },
+    "tslib": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -2044,6 +3525,12 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -2056,6 +3543,22 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
       "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+    },
+    "v8-compile-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
     },
     "which": {
       "version": "1.3.1",
@@ -2080,6 +3583,12 @@
       "requires": {
         "string-width": "^1.0.2 || 2"
       }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "5.1.0",
@@ -2126,6 +3635,15 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
+    },
     "write-file-atomic": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
@@ -2137,6 +3655,12 @@
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
       }
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "CloudEvents SDK for JavaScript",
   "main": "index.js",
   "scripts": {
+    "lint": "standardx",
+    "pretest": "npm run lint",
     "test": "mocha test/**/*.js",
     "coverage": "nyc --reporter=lcov --reporter=text npm run test",
     "precoverage-publish": "npm run coverage",
@@ -40,7 +42,11 @@
     "chai": "~4.2.0",
     "mocha": "~7.1.1",
     "nock": "~12.0.3",
-    "nyc": "~15.0.0"
+    "nyc": "~15.0.0",
+    "eslint-config-standard": "^14.1.1",
+    "eslint-plugin-import": "^2.20.2",
+    "eslint-plugin-node": "^11.1.0",
+    "standardx": "^5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/test/bindings/http/receiver_binary_0_2_tests.js
+++ b/test/bindings/http/receiver_binary_0_2_tests.js
@@ -41,10 +41,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.2", () => {
       // setup
       var payload = {};
       var attributes = {
-        "ce-specversion" : "specversion",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "Content-Type"   : "application/json"
+        "ce-specversion": "specversion",
+        "ce-source": "source",
+        "ce-id": "id",
+        "Content-Type": "application/json"
       };
 
       // act and assert
@@ -56,10 +56,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.2", () => {
       // setup
       var payload = {};
       var attributes = {
-        "ce-type"        : "type",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-source": "source",
+        "ce-id": "id",
+        "Content-Type": "application/json"
       };
 
       // act and assert
@@ -71,10 +71,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.2", () => {
       // setup
       var payload = {};
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "specversion",
-        "ce-id"          : "id",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "specversion",
+        "ce-id": "id",
+        "Content-Type": "application/json"
       };
 
       // act and assert
@@ -86,10 +86,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.2", () => {
       // setup
       var payload = {};
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "specversion",
-        "ce-source"      : "source",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "specversion",
+        "ce-source": "source",
+        "Content-Type": "application/json"
       };
 
       // act and assert
@@ -101,11 +101,11 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.2", () => {
       // setup
       var payload = {};
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "specversion",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "specversion",
+        "ce-source": "source",
+        "ce-id": "id",
+        "Content-Type": "application/json"
       };
 
       // act and assert
@@ -117,11 +117,11 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.2", () => {
       // setup
       var payload = {};
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "specversion",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "Content-Type"   : "text/html"
+        "ce-type": "type",
+        "ce-specversion": "specversion",
+        "ce-source": "source",
+        "ce-id": "id",
+        "Content-Type": "text/html"
       };
 
       // act and assert
@@ -133,11 +133,11 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.2", () => {
       // setup
       var payload = {};
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.2",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "0.2",
+        "ce-source": "source",
+        "ce-id": "id",
+        "Content-Type": "application/json"
       };
 
       // act and assert
@@ -150,16 +150,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.2", () => {
     it("Cloudevent contains 'type'", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.2",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "0.2",
+        "ce-source": "source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -173,16 +173,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.2", () => {
     it("Cloudevent contains 'specversion'", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.2",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "0.2",
+        "ce-source": "source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -196,16 +196,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.2", () => {
     it("Cloudevent contains 'source'", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.2",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "0.2",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -219,16 +219,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.2", () => {
     it("Cloudevent contains 'id'", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.2",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "0.2",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -242,16 +242,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.2", () => {
     it("Cloudevent contains 'time'", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.2",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00.000Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "0.2",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00.000Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -265,16 +265,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.2", () => {
     it("Cloudevent contains 'schemaurl'", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.2",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "0.2",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -288,16 +288,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.2", () => {
     it("Cloudevent contains 'contenttype' (application/json)", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.2",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "0.2",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -312,13 +312,13 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.2", () => {
       // setup
       var payload = "The payload is binary data";
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.2",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/octet-stream"
+        "ce-type": "type",
+        "ce-specversion": "0.2",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/octet-stream"
       };
 
       // act
@@ -332,16 +332,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.2", () => {
     it("Cloudevent contains 'data' (application/json)", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.2",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "0.2",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -356,13 +356,13 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.2", () => {
       // setup
       var payload = "The payload is binary data";
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.2",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/octet-stream"
+        "ce-type": "type",
+        "ce-specversion": "0.2",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/octet-stream"
       };
 
       // act
@@ -376,16 +376,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.2", () => {
     it("No error when all attributes are in place", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.2",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "0.2",
+        "ce-source": "source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -393,27 +393,27 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.2", () => {
 
       // assert
       expect(actual)
-          .to.be.an("object");
+        .to.be.an("object");
 
       expect(actual)
-          .to.have.property("format");
+        .to.have.property("format");
     });
 
     it("Should accept 'extension1'", () => {
       // setup
       var extension1 = "mycuston-ext1";
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.2",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/json",
-        "ce-extension1"  : extension1
+        "ce-type": "type",
+        "ce-specversion": "0.2",
+        "ce-source": "source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json",
+        "ce-extension1": extension1
       };
 
       // act
@@ -421,8 +421,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.2", () => {
       var actualExtensions = actual.getExtensions();
 
       // assert
-      expect(actualExtensions["extension1"])
-          .to.equal(extension1);
+      expect(actualExtensions.extension1)
+        .to.equal(extension1);
     });
   });
 });

--- a/test/bindings/http/receiver_binary_0_3_tests.js
+++ b/test/bindings/http/receiver_binary_0_3_tests.js
@@ -41,10 +41,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
       // setup
       var payload = {};
       var attributes = {
-        "ce-specversion" : "specversion",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "Content-Type"   : "application/json"
+        "ce-specversion": "specversion",
+        "ce-source": "source",
+        "ce-id": "id",
+        "Content-Type": "application/json"
       };
 
       // act and assert
@@ -56,10 +56,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
       // setup
       var payload = {};
       var attributes = {
-        "ce-type"        : "type",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-source": "source",
+        "ce-id": "id",
+        "Content-Type": "application/json"
       };
 
       // act and assert
@@ -71,10 +71,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
       // setup
       var payload = {};
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "specversion",
-        "ce-id"          : "id",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "specversion",
+        "ce-id": "id",
+        "Content-Type": "application/json"
       };
 
       // act and assert
@@ -86,10 +86,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
       // setup
       var payload = {};
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "specversion",
-        "ce-source"      : "source",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "specversion",
+        "ce-source": "source",
+        "Content-Type": "application/json"
       };
 
       // act and assert
@@ -101,11 +101,11 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
       // setup
       var payload = {};
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.2",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "0.2",
+        "ce-source": "source",
+        "ce-id": "id",
+        "Content-Type": "application/json"
       };
 
       // act and assert
@@ -117,11 +117,11 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
       // setup
       var payload = {};
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "specversion",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "Content-Type"   : "text/html"
+        "ce-type": "type",
+        "ce-specversion": "specversion",
+        "ce-source": "source",
+        "ce-id": "id",
+        "Content-Type": "text/html"
       };
 
       // act and assert
@@ -133,11 +133,11 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
       // setup
       var payload = {};
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.3",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "0.3",
+        "ce-source": "source",
+        "ce-id": "id",
+        "Content-Type": "application/json"
       };
 
       // act and assert
@@ -150,16 +150,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
     it("Cloudevent contains 'type'", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.3",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "0.3",
+        "ce-source": "source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -173,16 +173,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
     it("Cloudevent contains 'specversion'", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.3",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "0.3",
+        "ce-source": "source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -196,16 +196,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
     it("Cloudevent contains 'source'", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.3",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "0.3",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -219,16 +219,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
     it("Cloudevent contains 'id'", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.3",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "0.3",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -242,16 +242,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
     it("Cloudevent contains 'time'", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.3",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00.000Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "0.3",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00.000Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -265,16 +265,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
     it("Cloudevent contains 'schemaurl'", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.3",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "0.3",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -288,16 +288,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
     it("Cloudevent contains 'contenttype' (application/json)", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.3",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "0.3",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -312,13 +312,13 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
       // setup
       var payload = "The payload is binary data";
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.3",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/octet-stream"
+        "ce-type": "type",
+        "ce-specversion": "0.3",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/octet-stream"
       };
 
       // act
@@ -332,16 +332,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
     it("Cloudevent contains 'data' (application/json)", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.3",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "0.3",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -356,13 +356,13 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
       // setup
       var payload = "The payload is binary data";
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.3",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/octet-stream"
+        "ce-type": "type",
+        "ce-specversion": "0.3",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/octet-stream"
       };
 
       // act
@@ -376,16 +376,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
     it("No error when all attributes are in place", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.3",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "0.3",
+        "ce-source": "source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -393,27 +393,27 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
 
       // assert
       expect(actual)
-          .to.be.an("object");
+        .to.be.an("object");
 
       expect(actual)
-          .to.have.property("format");
+        .to.have.property("format");
     });
 
     it("Should accept 'extension1'", () => {
       // setup
       var extension1 = "mycuston-ext1";
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.3",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/json",
-        "ce-extension1"  : extension1
+        "ce-type": "type",
+        "ce-specversion": "0.3",
+        "ce-source": "source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json",
+        "ce-extension1": extension1
       };
 
       // act
@@ -421,8 +421,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
       var actualExtensions = actual.getExtensions();
 
       // assert
-      expect(actualExtensions["extension1"])
-          .to.equal(extension1);
+      expect(actualExtensions.extension1)
+        .to.equal(extension1);
     });
   });
 });

--- a/test/bindings/http/receiver_binary_1_tests.js
+++ b/test/bindings/http/receiver_binary_1_tests.js
@@ -1,5 +1,5 @@
 const expect = require("chai").expect;
-const {asBase64} = require("../../../lib/utils/fun.js");
+const { asBase64 } = require("../../../lib/utils/fun.js");
 
 const HTTPBinaryReceiver =
   require("../../../lib/bindings/http/receiver_binary_1.js");
@@ -42,10 +42,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
       // setup
       var payload = {};
       var attributes = {
-        "ce-specversion" : "specversion",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "Content-Type"   : "application/json"
+        "ce-specversion": "specversion",
+        "ce-source": "source",
+        "ce-id": "id",
+        "Content-Type": "application/json"
       };
 
       // act and assert
@@ -57,10 +57,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
       // setup
       var payload = {};
       var attributes = {
-        "ce-type"        : "type",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-source": "source",
+        "ce-id": "id",
+        "Content-Type": "application/json"
       };
 
       // act and assert
@@ -72,10 +72,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
       // setup
       var payload = {};
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "specversion",
-        "ce-id"          : "id",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "specversion",
+        "ce-id": "id",
+        "Content-Type": "application/json"
       };
 
       // act and assert
@@ -87,10 +87,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
       // setup
       var payload = {};
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "specversion",
-        "ce-source"      : "source",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "specversion",
+        "ce-source": "source",
+        "Content-Type": "application/json"
       };
 
       // act and assert
@@ -102,11 +102,11 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
       // setup
       var payload = {};
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.2",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "0.2",
+        "ce-source": "source",
+        "ce-id": "id",
+        "Content-Type": "application/json"
       };
 
       // act and assert
@@ -118,11 +118,11 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
       // setup
       var payload = {};
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "specversion",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "Content-Type"   : "text/html"
+        "ce-type": "type",
+        "ce-specversion": "specversion",
+        "ce-source": "source",
+        "ce-id": "id",
+        "Content-Type": "text/html"
       };
 
       // act and assert
@@ -134,11 +134,11 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
       // setup
       var payload = {};
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "1.0",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "1.0",
+        "ce-source": "source",
+        "ce-id": "id",
+        "Content-Type": "application/json"
       };
 
       // act and assert
@@ -151,16 +151,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
     it("Cloudevent contains 'type'", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "1.0",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-dataschema"  : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "1.0",
+        "ce-source": "source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-dataschema": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -174,16 +174,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
     it("Cloudevent contains 'specversion'", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "1.0",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-dataschema"  : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "1.0",
+        "ce-source": "source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-dataschema": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -197,16 +197,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
     it("Cloudevent contains 'source'", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "1.0",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-dataschema"  : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "1.0",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-dataschema": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -220,16 +220,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
     it("Cloudevent contains 'id'", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "1.0",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-dataschema"  : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "1.0",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-dataschema": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -243,16 +243,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
     it("Cloudevent contains 'time'", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "1.0",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00.000Z",
-        "ce-dataschema"  : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "1.0",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00.000Z",
+        "ce-dataschema": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -266,16 +266,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
     it("Cloudevent contains 'dataschema'", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "1.0",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-dataschema"  : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "1.0",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-dataschema": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -289,16 +289,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
     it("Cloudevent contains 'contenttype' (application/json)", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "1.0",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-dataschema"  : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "1.0",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-dataschema": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -313,13 +313,13 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
       // setup
       var payload = "The payload is binary data";
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "1.0",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-dataschema"  : "http://schema.registry/v1",
-        "Content-Type"   : "application/octet-stream"
+        "ce-type": "type",
+        "ce-specversion": "1.0",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-dataschema": "http://schema.registry/v1",
+        "Content-Type": "application/octet-stream"
       };
 
       // act
@@ -333,16 +333,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
     it("Cloudevent contains 'data' (application/json)", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "1.0",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-dataschema"  : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "1.0",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-dataschema": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -357,13 +357,13 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
       // setup
       var payload = "The payload is binary data";
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "1.0",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-dataschema"  : "http://schema.registry/v1",
-        "Content-Type"   : "application/octet-stream"
+        "ce-type": "type",
+        "ce-specversion": "1.0",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-dataschema": "http://schema.registry/v1",
+        "Content-Type": "application/octet-stream"
       };
 
       // act
@@ -377,20 +377,21 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
     it("The content of 'data' is base64 for binary", () => {
       // setup
       var expected = {
-        "data" : "dataString"
+        data: "dataString"
       };
 
-      let bindata = Uint32Array.from(JSON.stringify(expected), (c) => c.codePointAt(0));
-      let payload = asBase64(bindata);
+      const bindata = Uint32Array
+        .from(JSON.stringify(expected), (c) => c.codePointAt(0));
+      const payload = asBase64(bindata);
 
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "1.0",
-        "ce-source"      : "/source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-dataschema"  : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "1.0",
+        "ce-source": "/source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-dataschema": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -404,16 +405,16 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
     it("No error when all attributes are in place", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "1.0",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-dataschema"  : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "1.0",
+        "ce-source": "source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-dataschema": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       // act
@@ -421,27 +422,27 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
 
       // assert
       expect(actual)
-          .to.be.an("object");
+        .to.be.an("object");
 
       expect(actual)
-          .to.have.property("format");
+        .to.have.property("format");
     });
 
     it("Should accept 'extension1'", () => {
       // setup
       var extension1 = "mycuston-ext1";
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "1.0",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-dataschema"  : "http://schema.registry/v1",
-        "Content-Type"   : "application/json",
-        "ce-extension1"  : extension1
+        "ce-type": "type",
+        "ce-specversion": "1.0",
+        "ce-source": "source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-dataschema": "http://schema.registry/v1",
+        "Content-Type": "application/json",
+        "ce-extension1": extension1
       };
 
       // act
@@ -449,8 +450,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
       var actualExtensions = actual.getExtensions();
 
       // assert
-      expect(actualExtensions["extension1"])
-          .to.equal(extension1);
+      expect(actualExtensions.extension1)
+        .to.equal(extension1);
     });
   });
 });

--- a/test/bindings/http/receiver_structured_0_2_test.js
+++ b/test/bindings/http/receiver_structured_0_2_test.js
@@ -1,18 +1,15 @@
-var expect     = require("chai").expect;
+var expect = require("chai").expect;
 var Cloudevent = require("../../../index.js");
-var Spec02     = require("../../../lib/specs/spec_0_2.js");
 
 var HTTPStructuredReceiver02 =
   require("../../../lib/bindings/http/receiver_structured_0_2.js");
 
 var receiver = new HTTPStructuredReceiver02();
 
-const type        = "com.github.pull.create";
-const source      = "urn:event:from:myapi/resourse/123";
-const webhook     = "https://cloudevents.io/webhook";
-const contentType = "application/cloudevents+json; charset=utf-8";
-const now         = new Date();
-const schemaurl   = "http://cloudevents.io/schema.json";
+const type = "com.github.pull.create";
+const source = "urn:event:from:myapi/resourse/123";
+const now = new Date();
+const schemaurl = "http://cloudevents.io/schema.json";
 
 const ceContentType = "application/json";
 
@@ -20,83 +17,68 @@ const data = {
   foo: "bar"
 };
 
-const ext1Name  = "extension1";
-const ext1Value = "foobar";
-const ext2Name  = "extension2";
-const ext2Value = "acme";
-
-var cloudevent =
-  new Cloudevent(Spec02)
-    .type(type)
-    .source(source)
-    .contenttype(ceContentType)
-    .time(now)
-    .schemaurl(schemaurl)
-    .data(data)
-    .addExtension(ext1Name, ext1Value)
-    .addExtension(ext2Name, ext2Value);
-
-describe("HTTP Transport Binding Structured Receiver for CloudEvents v0.2", () => {
-  describe("Check", () => {
-    it("Throw error when payload arg is null or undefined", () => {
+describe("HTTP Transport Binding Structured Receiver for CloudEvents v0.2",
+  () => {
+    describe("Check", () => {
+      it("Throw error when payload arg is null or undefined", () => {
       // setup
-      var payload = null;
-      var attributes = {};
+        var payload = null;
+        var attributes = {};
 
-      // act and assert
-      expect(receiver.check.bind(receiver, payload, attributes))
-        .to.throw("payload is null or undefined");
+        // act and assert
+        expect(receiver.check.bind(receiver, payload, attributes))
+          .to.throw("payload is null or undefined");
+      });
+
+      it("Throw error when attributes arg is null or undefined", () => {
+      // setup
+        var payload = {};
+        var attributes = null;
+
+        // act and assert
+        expect(receiver.check.bind(receiver, payload, attributes))
+          .to.throw("attributes is null or undefined");
+      });
+
+      it("Throw error when payload is not an object or string", () => {
+      // setup
+        var payload = 1.0;
+        var attributes = {};
+
+        // act and assert
+        expect(receiver.check.bind(receiver, payload, attributes))
+          .to.throw("payload must be an object or string");
+      });
+
+      it("Throw error when the content-type is invalid", () => {
+      // setup
+        var payload = {};
+        var attributes = {
+          "Content-Type": "text/html"
+        };
+
+        // act and assert
+        expect(receiver.check.bind(receiver, payload, attributes))
+          .to.throw("invalid content type");
+      });
+
+      it("No error when all required stuff are in place", () => {
+      // setup
+        var payload = {};
+        var attributes = {
+          "Content-Type": "application/cloudevents+json"
+        };
+
+        // act and assert
+        expect(receiver.check.bind(receiver, payload, attributes))
+          .to.not.throw();
+      });
     });
 
-    it("Throw error when attributes arg is null or undefined", () => {
+    describe("Parse", () => {
+      it("Throw error when the event does not follow the spec 0.2", () => {
       // setup
-      var payload = {};
-      var attributes = null;
-
-      // act and assert
-      expect(receiver.check.bind(receiver, payload, attributes))
-        .to.throw("attributes is null or undefined");
-    });
-
-    it("Throw error when payload is not an object or string", () => {
-      // setup
-      var payload = 1.0;
-      var attributes = {};
-
-      // act and assert
-      expect(receiver.check.bind(receiver, payload, attributes))
-        .to.throw("payload must be an object or string");
-    });
-
-    it("Throw error when the content-type is invalid", () => {
-      // setup
-      var payload = {};
-      var attributes = {
-        "Content-Type" : "text/html"
-      };
-
-      // act and assert
-      expect(receiver.check.bind(receiver, payload, attributes))
-        .to.throw("invalid content type");
-    });
-
-    it("No error when all required stuff are in place", () => {
-      // setup
-      var payload = {};
-      var attributes = {
-        "Content-Type" : "application/cloudevents+json"
-      };
-
-      // act and assert
-      expect(receiver.check.bind(receiver, payload, attributes))
-        .to.not.throw();
-    });
-  });
-
-  describe("Parse", () => {
-    it("Throw error when the event does not follow the spec 0.2", () => {
-      // setup
-      var payload =
+        var payload =
         new Cloudevent()
           .type(type)
           .source(source)
@@ -106,19 +88,19 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v0.2", () =
           .data(data)
           .toString();
 
-      var headers = {
-        "Content-Type":"application/cloudevents+json"
-      };
+        var headers = {
+          "Content-Type": "application/cloudevents+json"
+        };
 
-      // act and assert
-      expect(receiver.parse.bind(receiver, payload, headers))
-        .to.throw("invalid payload");
-    });
+        // act and assert
+        expect(receiver.parse.bind(receiver, payload, headers))
+          .to.throw("invalid payload");
+      });
 
-    it("Should accept event that follow the spec 0.2", () => {
+      it("Should accept event that follow the spec 0.2", () => {
       // setup
-      var id = "id-x0dk";
-      var payload =
+        var id = "id-x0dk";
+        var payload =
         new Cloudevent(Cloudevent.specs["0.2"])
           .type(type)
           .source(source)
@@ -128,28 +110,28 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v0.2", () =
           .schemaurl(schemaurl)
           .data(data)
           .toString();
-      var headers = {
-        "content-type":"application/cloudevents+json"
-      };
+        var headers = {
+          "content-type": "application/cloudevents+json"
+        };
 
-      // act
-      var actual = receiver.parse(payload, headers);
+        // act
+        var actual = receiver.parse(payload, headers);
 
-      // assert
-      expect(actual)
+        // assert
+        expect(actual)
           .to.be.an("object");
 
-      expect(actual)
+        expect(actual)
           .to.have.property("format");
 
-      expect(actual.getId())
+        expect(actual.getId())
           .to.equals(id);
-    });
+      });
 
-    it("Should accept 'extension1'", () => {
+      it("Should accept 'extension1'", () => {
       // setup
-      var extension1 = "mycuston-ext1"
-      var payload =
+        var extension1 = "mycuston-ext1";
+        var payload =
         new Cloudevent(Cloudevent.specs["0.2"])
           .type(type)
           .source(source)
@@ -160,17 +142,17 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v0.2", () =
           .addExtension("extension1", extension1)
           .toString();
 
-      var headers = {
-        "content-type":"application/cloudevents+json"
-      };
+        var headers = {
+          "content-type": "application/cloudevents+json"
+        };
 
-      // act
-      var actual = receiver.parse(payload, headers);
-      var actualExtensions = actual.getExtensions();
+        // act
+        var actual = receiver.parse(payload, headers);
+        var actualExtensions = actual.getExtensions();
 
-      // assert
-      expect(actualExtensions["extension1"])
+        // assert
+        expect(actualExtensions.extension1)
           .to.equal(extension1);
+      });
     });
   });
-});

--- a/test/bindings/http/receiver_structured_0_3_test.js
+++ b/test/bindings/http/receiver_structured_0_3_test.js
@@ -1,138 +1,114 @@
-var expect     = require("chai").expect;
+var expect = require("chai").expect;
 var v03 = require("../../../v03/index.js");
 var Cloudevent = require("../../../index.js");
-var Spec     = require("../../../lib/specs/spec_0_3.js");
 
 var HTTPStructuredReceiver =
   require("../../../lib/bindings/http/receiver_structured_0_3.js");
 
 var receiver = new HTTPStructuredReceiver();
 
-const type        = "com.github.pull.create";
-const source      = "urn:event:from:myapi/resourse/123";
-const webhook     = "https://cloudevents.io/webhook";
-const contentEncoding = "base64";
-const contentType = "application/cloudevents+json; charset=utf-8";
-const now         = new Date();
-const schemaurl   = "http://cloudevents.io/schema.json";
+const type = "com.github.pull.create";
+const source = "urn:event:from:myapi/resourse/123";
+const now = new Date();
+const schemaurl = "http://cloudevents.io/schema.json";
 
 const ceContentType = "application/json";
 
 const data = {
   foo: "bar"
 };
-const dataBase64 = "Y2xvdWRldmVudHMK";
 
-const ext1Name  = "extension1";
+const ext1Name = "extension1";
 const ext1Value = "foobar";
-const ext2Name  = "extension2";
+const ext2Name = "extension2";
 const ext2Value = "acme";
 
-var cloudevent = v03.event()
-    .type(type)
-    .source(source)
-    .contenttype(ceContentType)
-    .time(now)
-    .schemaurl(schemaurl)
-    .data(data)
-    .addExtension(ext1Name, ext1Value)
-    .addExtension(ext2Name, ext2Value);
-
-const cebase64 = v03.event()
-    .type(type)
-    .source(source)
-    .dataContentType(ceContentType)
-    .dataContentEncoding(contentEncoding)
-    .time(now)
-    .schemaurl(schemaurl)
-    .data(dataBase64)
-    .addExtension(ext1Name, ext1Value)
-    .addExtension(ext2Name, ext2Value);
-
-describe("HTTP Transport Binding Structured Receiver for CloudEvents v0.3", () => {
-  describe("Check", () => {
-    it("Throw error when payload arg is null or undefined", () => {
+describe("HTTP Transport Binding Structured Receiver for CloudEvents v0.3",
+  () => {
+    describe("Check", () => {
+      it("Throw error when payload arg is null or undefined", () => {
       // setup
-      var payload = null;
-      var attributes = {};
+        var payload = null;
+        var attributes = {};
 
-      // act and assert
-      expect(receiver.check.bind(receiver, payload, attributes))
-        .to.throw("payload is null or undefined");
+        // act and assert
+        expect(receiver.check.bind(receiver, payload, attributes))
+          .to.throw("payload is null or undefined");
+      });
+
+      it("Throw error when attributes arg is null or undefined", () => {
+      // setup
+        var payload = {};
+        var attributes = null;
+
+        // act and assert
+        expect(receiver.check.bind(receiver, payload, attributes))
+          .to.throw("attributes is null or undefined");
+      });
+
+      it("Throw error when payload is not an object or string", () => {
+      // setup
+        var payload = 1.0;
+        var attributes = {};
+
+        // act and assert
+        expect(receiver.check.bind(receiver, payload, attributes))
+          .to.throw("payload must be an object or string");
+      });
+
+      it("Throw error when the content-type is invalid", () => {
+      // setup
+        var payload = {};
+        var attributes = {
+          "Content-Type": "text/html"
+        };
+
+        // act and assert
+        expect(receiver.check.bind(receiver, payload, attributes))
+          .to.throw("invalid content type");
+      });
+
+      it("Throw error data content encoding is base64, but 'data' is not",
+        () => {
+        // setup
+          const payload = v03.event()
+            .type(type)
+            .source(source)
+            .dataContentType("text/plain")
+            .dataContentEncoding("base64")
+            .time(now)
+            .schemaurl(schemaurl)
+            .data("No base 64 value")
+            .addExtension(ext1Name, ext1Value)
+            .addExtension(ext2Name, ext2Value)
+            .toString();
+
+          const attributes = {
+            "Content-Type": "application/cloudevents+json"
+          };
+
+          // act and assert
+          expect(receiver.parse.bind(receiver, payload, attributes))
+            .to.throw("invalid payload");
+        });
+
+      it("No error when all required stuff are in place", () => {
+      // setup
+        var payload = {};
+        var attributes = {
+          "Content-Type": "application/cloudevents+json"
+        };
+
+        // act and assert
+        expect(receiver.check.bind(receiver, payload, attributes))
+          .to.not.throw();
+      });
     });
 
-    it("Throw error when attributes arg is null or undefined", () => {
+    describe("Parse", () => {
+      it("Throw error when the event does not follow the spec", () => {
       // setup
-      var payload = {};
-      var attributes = null;
-
-      // act and assert
-      expect(receiver.check.bind(receiver, payload, attributes))
-        .to.throw("attributes is null or undefined");
-    });
-
-    it("Throw error when payload is not an object or string", () => {
-      // setup
-      var payload = 1.0;
-      var attributes = {};
-
-      // act and assert
-      expect(receiver.check.bind(receiver, payload, attributes))
-        .to.throw("payload must be an object or string");
-    });
-
-    it("Throw error when the content-type is invalid", () => {
-      // setup
-      var payload = {};
-      var attributes = {
-        "Content-Type" : "text/html"
-      };
-
-      // act and assert
-      expect(receiver.check.bind(receiver, payload, attributes))
-        .to.throw("invalid content type");
-    });
-
-    it("Throw error data content encoding is base64, but 'data' is not", () => {
-      // setup
-      let payload = v03.event()
-          .type(type)
-          .source(source)
-          .dataContentType("text/plain")
-          .dataContentEncoding("base64")
-          .time(now)
-          .schemaurl(schemaurl)
-          .data("No base 64 value")
-          .addExtension(ext1Name, ext1Value)
-          .addExtension(ext2Name, ext2Value)
-          .toString();
-
-      let attributes = {
-        "Content-Type" : "application/cloudevents+json"
-      };
-
-      // act and assert
-      expect(receiver.parse.bind(receiver, payload, attributes))
-        .to.throw("invalid payload");
-    });
-
-    it("No error when all required stuff are in place", () => {
-      // setup
-      var payload = {};
-      var attributes = {
-        "Content-Type" : "application/cloudevents+json"
-      };
-
-      // act and assert
-      expect(receiver.check.bind(receiver, payload, attributes))
-        .to.not.throw();
-    });
-  });
-
-  describe("Parse", () => {
-    it("Throw error when the event does not follow the spec", () => {
-      // setup
-      var payload =
+        var payload =
         new Cloudevent()
           .type(type)
           .source(source)
@@ -142,19 +118,19 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v0.3", () =
           .data(data)
           .toString();
 
-      var headers = {
-        "Content-Type":"application/cloudevents+json"
-      };
+        var headers = {
+          "Content-Type": "application/cloudevents+json"
+        };
 
-      // act and assert
-      expect(receiver.parse.bind(receiver, payload, headers))
-        .to.throw("invalid payload");
-    });
+        // act and assert
+        expect(receiver.parse.bind(receiver, payload, headers))
+          .to.throw("invalid payload");
+      });
 
-    it("Should accept event that follows the spec", () => {
+      it("Should accept event that follows the spec", () => {
       // setup
-      var id = "id-x0dk";
-      var payload = v03.event()
+        var id = "id-x0dk";
+        var payload = v03.event()
           .type(type)
           .source(source)
           .id(id)
@@ -163,28 +139,28 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v0.3", () =
           .schemaurl(schemaurl)
           .data(data)
           .toString();
-      var headers = {
-        "content-type":"application/cloudevents+json"
-      };
+        var headers = {
+          "content-type": "application/cloudevents+json"
+        };
 
-      // act
-      var actual = receiver.parse(payload, headers);
+        // act
+        var actual = receiver.parse(payload, headers);
 
-      // assert
-      expect(actual)
+        // assert
+        expect(actual)
           .to.be.an("object");
 
-      expect(actual)
+        expect(actual)
           .to.have.property("format");
 
-      expect(actual.getId())
+        expect(actual.getId())
           .to.equals(id);
-    });
+      });
 
-    it("Should accept 'extension1'", () => {
+      it("Should accept 'extension1'", () => {
       // setup
-      var extension1 = "mycuston-ext1"
-      var payload = v03.event()
+        var extension1 = "mycuston-ext1";
+        var payload = v03.event()
           .type(type)
           .source(source)
           .contenttype(ceContentType)
@@ -194,22 +170,22 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v0.3", () =
           .addExtension("extension1", extension1)
           .toString();
 
-      var headers = {
-        "content-type":"application/cloudevents+json"
-      };
+        var headers = {
+          "content-type": "application/cloudevents+json"
+        };
 
-      // act
-      var actual = receiver.parse(payload, headers);
-      var actualExtensions = actual.getExtensions();
+        // act
+        var actual = receiver.parse(payload, headers);
+        var actualExtensions = actual.getExtensions();
 
-      // assert
-      expect(actualExtensions["extension1"])
+        // assert
+        expect(actualExtensions.extension1)
           .to.equal(extension1);
-    });
+      });
 
-    it("Should parse 'data' stringfied json to json object", () => {
+      it("Should parse 'data' stringfied json to json object", () => {
       // setup
-      var payload = v03.event()
+        var payload = v03.event()
           .type(type)
           .source(source)
           .contenttype(ceContentType)
@@ -218,15 +194,15 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v0.3", () =
           .data(JSON.stringify(data))
           .toString();
 
-      var headers = {
-        "content-type":"application/cloudevents+json"
-      };
+        var headers = {
+          "content-type": "application/cloudevents+json"
+        };
 
-      // act
-      var actual = receiver.parse(payload, headers);
+        // act
+        var actual = receiver.parse(payload, headers);
 
-      // assert
-      expect(actual.getData()).to.deep.equal(data);
+        // assert
+        expect(actual.getData()).to.deep.equal(data);
+      });
     });
   });
-});

--- a/test/bindings/http/receiver_structured_1_test.js
+++ b/test/bindings/http/receiver_structured_1_test.js
@@ -1,22 +1,18 @@
-var expect     = require("chai").expect;
+var expect = require("chai").expect;
 var v1 = require("../../../v1/index.js");
 var Cloudevent = require("../../../index.js");
-var Spec     = require("../../../lib/specs/spec_1.js");
 
-const {asBase64} = require("../../../lib/utils/fun.js");
+const { asBase64 } = require("../../../lib/utils/fun.js");
 
 var HTTPStructuredReceiver =
   require("../../../lib/bindings/http/receiver_structured_1.js");
 
 var receiver = new HTTPStructuredReceiver();
 
-const type        = "com.github.pull.create";
-const source      = "urn:event:from:myapi/resourse/123";
-const webhook     = "https://cloudevents.io/webhook";
-const contentEncoding = "base64";
-const contentType = "application/cloudevents+json; charset=utf-8";
-const now         = new Date();
-const dataschema  = "http://cloudevents.io/schema.json";
+const type = "com.github.pull.create";
+const source = "urn:event:from:myapi/resourse/123";
+const now = new Date();
+const dataschema = "http://cloudevents.io/schema.json";
 
 const ceContentType = "application/json";
 
@@ -24,72 +20,68 @@ const data = {
   foo: "bar"
 };
 
-const ext1Name  = "extension1";
-const ext1Value = "foobar";
-const ext2Name  = "extension2";
-const ext2Value = "acme";
-
-describe("HTTP Transport Binding Structured Receiver for CloudEvents v1.0", () => {
-  describe("Check", () => {
-    it("Throw error when payload arg is null or undefined", () => {
+describe("HTTP Transport Binding Structured Receiver for CloudEvents v1.0",
+  () => {
+    describe("Check", () => {
+      it("Throw error when payload arg is null or undefined", () => {
       // setup
-      var payload = null;
-      var attributes = {};
+        var payload = null;
+        var attributes = {};
 
-      // act and assert
-      expect(receiver.check.bind(receiver, payload, attributes))
-        .to.throw("payload is null or undefined");
+        // act and assert
+        expect(receiver.check.bind(receiver, payload, attributes))
+          .to.throw("payload is null or undefined");
+      });
+
+      it("Throw error when attributes arg is null or undefined", () => {
+      // setup
+        var payload = {};
+        var attributes = null;
+
+        // act and assert
+        expect(receiver.check.bind(receiver, payload, attributes))
+          .to.throw("attributes is null or undefined");
+      });
+
+      it("Throw error when payload is not an object or string", () => {
+      // setup
+        var payload = 1.0;
+        var attributes = {};
+
+        // act and assert
+        expect(receiver.check.bind(receiver, payload, attributes))
+          .to.throw("payload must be an object or string");
+      });
+
+      it("Throw error when the content-type is invalid", () => {
+      // setup
+        var payload = {};
+        var attributes = {
+          "Content-Type": "text/html"
+        };
+
+        // act and assert
+        expect(receiver.check.bind(receiver, payload, attributes))
+          .to.throw("invalid content type");
+      });
+
+      it("No error when all required stuff are in place", () => {
+      // setup
+        var payload = {};
+        var attributes = {
+          "Content-Type": "application/cloudevents+json"
+        };
+
+        // act and assert
+        expect(receiver.check.bind(receiver, payload, attributes))
+          .to.not.throw();
+      });
     });
 
-    it("Throw error when attributes arg is null or undefined", () => {
+    describe("Parse", () => {
+      it("Throw error when the event does not follow the spec", () => {
       // setup
-      var payload = {};
-      var attributes = null;
-
-      // act and assert
-      expect(receiver.check.bind(receiver, payload, attributes))
-        .to.throw("attributes is null or undefined");
-    });
-
-    it("Throw error when payload is not an object or string", () => {
-      // setup
-      var payload = 1.0;
-      var attributes = {};
-
-      // act and assert
-      expect(receiver.check.bind(receiver, payload, attributes))
-        .to.throw("payload must be an object or string");
-    });
-
-    it("Throw error when the content-type is invalid", () => {
-      // setup
-      var payload = {};
-      var attributes = {
-        "Content-Type" : "text/html"
-      };
-
-      // act and assert
-      expect(receiver.check.bind(receiver, payload, attributes))
-        .to.throw("invalid content type");
-    });
-
-    it("No error when all required stuff are in place", () => {
-      // setup
-      var payload = {};
-      var attributes = {
-        "Content-Type" : "application/cloudevents+json"
-      };
-
-      // act and assert
-      expect(receiver.check.bind(receiver, payload, attributes))
-        .to.not.throw();
-    });
-  });
-
-  describe("Parse", () => {
-    it("Throw error when the event does not follow the spec", () => {
-      // setup
-      var payload =
+        var payload =
         new Cloudevent()
           .type(type)
           .source(source)
@@ -97,19 +89,19 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v1.0", () =
           .data(data)
           .toString();
 
-      var headers = {
-        "Content-Type":"application/cloudevents+json"
-      };
+        var headers = {
+          "Content-Type": "application/cloudevents+json"
+        };
 
-      // act and assert
-      expect(receiver.parse.bind(receiver, payload, headers))
-        .to.throw("invalid payload");
-    });
+        // act and assert
+        expect(receiver.parse.bind(receiver, payload, headers))
+          .to.throw("invalid payload");
+      });
 
-    it("Should accept event that follows the spec", () => {
+      it("Should accept event that follows the spec", () => {
       // setup
-      var id = "id-x0dk";
-      var payload = v1.event()
+        var id = "id-x0dk";
+        var payload = v1.event()
           .type(type)
           .source(source)
           .id(id)
@@ -118,28 +110,28 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v1.0", () =
           .dataschema(dataschema)
           .data(data)
           .toString();
-      var headers = {
-        "content-type":"application/cloudevents+json"
-      };
+        var headers = {
+          "content-type": "application/cloudevents+json"
+        };
 
-      // act
-      var actual = receiver.parse(payload, headers);
+        // act
+        var actual = receiver.parse(payload, headers);
 
-      // assert
-      expect(actual)
+        // assert
+        expect(actual)
           .to.be.an("object");
 
-      expect(actual)
+        expect(actual)
           .to.have.property("format");
 
-      expect(actual.getId())
+        expect(actual.getId())
           .to.equals(id);
-    });
+      });
 
-    it("Should accept 'extension1'", () => {
+      it("Should accept 'extension1'", () => {
       // setup
-      var extension1 = "mycuston-ext1"
-      var payload = v1.event()
+        var extension1 = "mycuston-ext1";
+        var payload = v1.event()
           .type(type)
           .source(source)
           .dataContentType(ceContentType)
@@ -149,22 +141,22 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v1.0", () =
           .addExtension("extension1", extension1)
           .toString();
 
-      var headers = {
-        "content-type":"application/cloudevents+json"
-      };
+        var headers = {
+          "content-type": "application/cloudevents+json"
+        };
 
-      // act
-      var actual = receiver.parse(payload, headers);
-      var actualExtensions = actual.getExtensions();
+        // act
+        var actual = receiver.parse(payload, headers);
+        var actualExtensions = actual.getExtensions();
 
-      // assert
-      expect(actualExtensions["extension1"])
+        // assert
+        expect(actualExtensions.extension1)
           .to.equal(extension1);
-    });
+      });
 
-    it("Should parse 'data' stringfied json to json object", () => {
+      it("Should parse 'data' stringfied json to json object", () => {
       // setup
-      var payload = v1.event()
+        var payload = v1.event()
           .type(type)
           .source(source)
           .dataContentType(ceContentType)
@@ -173,37 +165,38 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v1.0", () =
           .data(JSON.stringify(data))
           .toString();
 
-      var headers = {
-        "content-type":"application/cloudevents+json"
-      };
+        var headers = {
+          "content-type": "application/cloudevents+json"
+        };
 
-      // act
-      var actual = receiver.parse(payload, headers);
+        // act
+        var actual = receiver.parse(payload, headers);
 
-      // assert
-      expect(actual.getData()).to.deep.equal(data);
-    });
+        // assert
+        expect(actual.getData()).to.deep.equal(data);
+      });
 
-    it("Should maps 'data_base64' to 'data' attribute", () => {
+      it("Should maps 'data_base64' to 'data' attribute", () => {
       // setup
-      let bindata = Uint32Array.from(JSON.stringify(data), (c) => c.codePointAt(0));
-      let expected = asBase64(bindata);
-      let payload = v1.event()
-            .type(type)
-            .source(source)
-            .dataContentType(ceContentType)
-            .data(bindata)
-            .format();
+        const bindata = Uint32Array
+          .from(JSON.stringify(data), (c) => c.codePointAt(0));
+        const expected = asBase64(bindata);
+        const payload = v1.event()
+          .type(type)
+          .source(source)
+          .dataContentType(ceContentType)
+          .data(bindata)
+          .format();
 
-      var headers = {
-        "content-type":"application/cloudevents+json"
-      };
+        var headers = {
+          "content-type": "application/cloudevents+json"
+        };
 
-      // act
-      var actual = receiver.parse(JSON.stringify(payload), headers);
+        // act
+        var actual = receiver.parse(JSON.stringify(payload), headers);
 
-      // assert
-      expect(actual.getData()).to.equal(expected);
+        // assert
+        expect(actual.getData()).to.equal(expected);
+      });
     });
   });
-});

--- a/test/bindings/http/unmarshaller_0_2_tests.js
+++ b/test/bindings/http/unmarshaller_0_2_tests.js
@@ -1,13 +1,11 @@
 var expect = require("chai").expect;
 var Unmarshaller = require("../../../http/unmarshaller/v02.js");
-var Cloudevent   = require("../../../index.js");
+var Cloudevent = require("../../../index.js");
 
-const type        = "com.github.pull.create";
-const source      = "urn:event:from:myapi/resourse/123";
-const webhook     = "https://cloudevents.io/webhook";
-const contentType = "application/cloudevents+json; charset=utf-8";
-const now         = new Date();
-const schemaurl   = "http://cloudevents.io/schema.json";
+const type = "com.github.pull.create";
+const source = "urn:event:from:myapi/resourse/123";
+const now = new Date();
+const schemaurl = "http://cloudevents.io/schema.json";
 
 const ceContentType = "application/json";
 
@@ -16,7 +14,6 @@ const data = {
 };
 
 describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.2", () => {
-
   it("Throw error when payload is null", () => {
     // setup
     var payload = null;
@@ -24,8 +21,8 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.2", () => {
 
     // act and assert
     return un.unmarshall(payload)
-      .then(actual => {throw {message: "failed"}})
-      .catch(err =>
+      .then(() => { throw new Error("failed"); })
+      .catch((err) =>
         expect(err.message).to.equal("payload is null or undefined"));
   });
 
@@ -37,8 +34,8 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.2", () => {
 
     // act and assert
     return un.unmarshall(payload, headers)
-      .then(actual => {throw {message: "failed"}})
-      .catch(err =>
+      .then(() => { throw new Error("failed"); })
+      .catch((err) =>
         expect(err.message).to.equal("headers is null or undefined"));
   });
 
@@ -50,8 +47,8 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.2", () => {
 
     // act and assert
     un.unmarshall(payload, headers)
-      .then(actual => {throw {message: "failed"}})
-      .catch(err =>
+      .then(() => { throw new Error("failed"); })
+      .catch((err) =>
         expect(err.message).to.equal("content-type header not found"));
   });
 
@@ -59,14 +56,14 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.2", () => {
     // setup
     var payload = {};
     var headers = {
-      "content-type":"text/xml"
+      "content-type": "text/xml"
     };
     var un = new Unmarshaller();
 
     // act and assert
     un.unmarshall(payload, headers)
-      .then(actual => {throw {message: "failed"}})
-      .catch(err =>
+      .then(() => { throw new Error("failed"); })
+      .catch((err) =>
         expect(err.message).to.equal("content type not allowed"));
   });
 
@@ -75,14 +72,14 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.2", () => {
       // setup
       var payload = {};
       var headers = {
-        "content-type":"application/cloudevents+zip"
+        "content-type": "application/cloudevents+zip"
       };
       var un = new Unmarshaller();
 
       // act and assert
       un.unmarshall(payload, headers)
-        .then(actual => {throw {message: "failed"}})
-        .catch(err =>
+        .then(() => { throw new Error("failed"); })
+        .catch((err) =>
           expect(err.message).to.equal("structured+type not allowed"));
     });
 
@@ -99,15 +96,15 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.2", () => {
           .toString();
 
       var headers = {
-        "content-type":"application/cloudevents+json"
+        "content-type": "application/cloudevents+json"
       };
 
       var un = new Unmarshaller();
 
       // act and assert
       un.unmarshall(payload, headers)
-        .then(actual => {throw {message: "failed"}})
-        .catch(err =>
+        .then(() => { throw new Error("failed"); })
+        .catch((err) =>
           expect(err.message).to.equal("invalid payload"));
     });
 
@@ -124,16 +121,15 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.2", () => {
           .toString();
 
       var headers = {
-        "content-type":"application/cloudevents+json"
+        "content-type": "application/cloudevents+json"
       };
 
       var un = new Unmarshaller();
 
       // act and assert
       un.unmarshall(payload, headers)
-        .then(actual =>
+        .then((actual) =>
           expect(actual).to.be.an("object"));
-
     });
   });
 
@@ -141,73 +137,71 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.2", () => {
     it("Throw error when has not allowed mime", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.2",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "text/html"
+        "ce-type": "type",
+        "ce-specversion": "0.2",
+        "ce-source": "source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "text/html"
       };
 
       var un = new Unmarshaller();
 
       // act and assert
       un.unmarshall(payload, attributes)
-        .then(actual => {throw {message: "failed"}})
-        .catch(err =>
+        .then(() => { throw new Error("failed"); })
+        .catch((err) =>
           expect(err.message).to.equal("content type not allowed"));
-
     });
 
     it("Throw error when the event does not follow the spec 0.2", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"               : "type",
-        "CE-CloudEventsVersion" : "0.1",
-        "ce-source"             : "source",
-        "ce-id"                 : "id",
-        "ce-time"               : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"          : "http://schema.registry/v1",
-        "Content-Type"          : "application/json"
+        "ce-type": "type",
+        "CE-CloudEventsVersion": "0.1",
+        "ce-source": "source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       var un = new Unmarshaller();
 
       // act and assert
       un.unmarshall(payload, attributes)
-        .then(actual => {throw {message: "failed"}})
-        .catch(err =>
+        .then(() => { throw new Error("failed"); })
+        .catch((err) =>
           expect(err.message).to.not.empty);
     });
 
     it("No error when all attributes are in place", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.2",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "0.2",
+        "ce-source": "source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       var un = new Unmarshaller();
 
       // act and assert
       un.unmarshall(payload, attributes)
-        .then(actual => expect(actual).to.be.an("object"));
-
+        .then((actual) => expect(actual).to.be.an("object"));
     });
   });
 });

--- a/test/bindings/http/unmarshaller_0_3_tests.js
+++ b/test/bindings/http/unmarshaller_0_3_tests.js
@@ -1,15 +1,13 @@
 var expect = require("chai").expect;
 var Unmarshaller = require("../../../lib/bindings/http/unmarshaller_0_3.js");
-var Cloudevent   = require("../../../index.js");
-var v03     = require("../../../v03/index.js");
+var Cloudevent = require("../../../index.js");
+var v03 = require("../../../v03/index.js");
 
-const type        = "com.github.pull.create";
-const source      = "urn:event:from:myapi/resourse/123";
-const webhook     = "https://cloudevents.io/webhook";
-const contentType = "application/cloudevents+json; charset=utf-8";
-const now         = new Date();
-const schemaurl   = "http://cloudevents.io/schema.json";
-const subject     = "subject.ext";
+const type = "com.github.pull.create";
+const source = "urn:event:from:myapi/resourse/123";
+const now = new Date();
+const schemaurl = "http://cloudevents.io/schema.json";
+const subject = "subject.ext";
 const ceContentType = "application/json";
 
 const data = {
@@ -17,7 +15,6 @@ const data = {
 };
 
 describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
-
   it("Throw error when payload is null", () => {
     // setup
     var payload = null;
@@ -25,8 +22,8 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
 
     // act and assert
     return un.unmarshall(payload)
-      .then(actual => {throw {message: "failed"}})
-      .catch(err =>
+      .then(() => { throw new Error("failed"); })
+      .catch((err) =>
         expect(err.message).to.equal("payload is null or undefined"));
   });
 
@@ -38,8 +35,8 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
 
     // act and assert
     return un.unmarshall(payload, headers)
-      .then(actual => {throw {message: "failed"}})
-      .catch(err =>
+      .then(() => { throw new Error("failed"); })
+      .catch((err) =>
         expect(err.message).to.equal("headers is null or undefined"));
   });
 
@@ -51,8 +48,8 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
 
     // act and assert
     un.unmarshall(payload, headers)
-      .then(actual => {throw {message: "failed"}})
-      .catch(err =>
+      .then(() => { throw new Error("failed"); })
+      .catch((err) =>
         expect(err.message).to.equal("content-type header not found"));
   });
 
@@ -60,14 +57,14 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
     // setup
     var payload = {};
     var headers = {
-      "content-type":"text/xml"
+      "content-type": "text/xml"
     };
     var un = new Unmarshaller();
 
     // act and assert
     un.unmarshall(payload, headers)
-      .then(actual => {throw {message: "failed"}})
-      .catch(err =>
+      .then(() => { throw new Error("failed"); })
+      .catch((err) =>
         expect(err.message).to.equal("content type not allowed"));
   });
 
@@ -76,14 +73,14 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
       // setup
       var payload = {};
       var headers = {
-        "content-type":"application/cloudevents+zip"
+        "content-type": "application/cloudevents+zip"
       };
       var un = new Unmarshaller();
 
       // act and assert
       un.unmarshall(payload, headers)
-        .then(actual => {throw {message: "failed"}})
-        .catch(err =>
+        .then(() => { throw new Error("failed"); })
+        .catch((err) =>
           expect(err.message).to.equal("structured+type not allowed"));
     });
 
@@ -100,15 +97,15 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
           .toString();
 
       var headers = {
-        "content-type":"application/cloudevents+json"
+        "content-type": "application/cloudevents+json"
       };
 
       var un = new Unmarshaller();
 
       // act and assert
       un.unmarshall(payload, headers)
-        .then(actual => {throw {message: "failed"}})
-        .catch(err =>
+        .then(() => { throw new Error("failed"); })
+        .catch((err) =>
           expect(err.message).to.equal("invalid payload"));
     });
 
@@ -126,20 +123,19 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
           .toString();
 
       var headers = {
-        "content-type":"application/cloudevents+json"
+        "content-type": "application/cloudevents+json"
       };
 
       var un = new Unmarshaller();
 
       // act and assert
       return un.unmarshall(payload, headers)
-        .then(actual =>
+        .then((actual) =>
           expect(actual).to.be.an("object"))
         .catch((err) => {
-          console.log(err);
+          console.error(err);
           throw err;
         });
-
     });
 
     it("Should parse 'data' stringfied json to json object", () => {
@@ -156,21 +152,20 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
           .toString();
 
       var headers = {
-        "content-type":"application/cloudevents+json"
+        "content-type": "application/cloudevents+json"
       };
 
       var un = new Unmarshaller();
 
       // act and assert
       return un.unmarshall(payload, headers)
-        .then(actual => {
-          expect(actual.getData()).to.deep.equal(data)
+        .then((actual) => {
+          expect(actual.getData()).to.deep.equal(data);
         })
         .catch((err) => {
-          console.log(err);
+          console.error(err);
           throw err;
         });
-
     });
   });
 
@@ -178,72 +173,71 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
     it("Throw error when has not allowed mime", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.3",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "text/html"
+        "ce-type": "type",
+        "ce-specversion": "0.3",
+        "ce-source": "source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "text/html"
       };
 
       var un = new Unmarshaller();
 
       // act and assert
       un.unmarshall(payload, attributes)
-        .then(actual => {throw {message: "failed"}})
-        .catch(err =>
+        .then(() => { throw new Error("failed"); })
+        .catch((err) =>
           expect(err.message).to.equal("content type not allowed"));
-
     });
 
     it("Throw error when the event does not follow the spec 0.3", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"               : "type",
-        "CE-CloudEventsVersion" : "0.1",
-        "ce-source"             : "source",
-        "ce-id"                 : "id",
-        "ce-time"               : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"          : "http://schema.registry/v1",
-        "Content-Type"          : "application/json"
+        "ce-type": "type",
+        "CE-CloudEventsVersion": "0.1",
+        "ce-source": "source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       var un = new Unmarshaller();
 
       // act and assert
       un.unmarshall(payload, attributes)
-        .then(actual => {throw {message: "failed"}})
-        .catch(err =>
+        .then(() => { throw new Error("failed"); })
+        .catch((err) =>
           expect(err.message).to.not.empty);
     });
 
     it("No error when all attributes are in place", () => {
       // setup
       var payload = {
-        "data" : "dataString"
+        data: "dataString"
       };
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.3",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/json"
+        "ce-type": "type",
+        "ce-specversion": "0.3",
+        "ce-source": "source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json"
       };
 
       var un = new Unmarshaller();
 
       // act and assert
       un.unmarshall(payload, attributes)
-        .then(actual => expect(actual).to.be.an("object"));
+        .then((actual) => expect(actual).to.be.an("object"));
     });
 
     it("Throw error when 'ce-datacontentencoding' is not allowed", () => {
@@ -251,22 +245,22 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
       var payload = "eyJtdWNoIjoid293In0=";
 
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.3",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/json",
-        "ce-datacontentencoding" : "binary"
+        "ce-type": "type",
+        "ce-specversion": "0.3",
+        "ce-source": "source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json",
+        "ce-datacontentencoding": "binary"
       };
 
       var un = new Unmarshaller();
 
       // act and assert
       return un.unmarshall(payload, attributes)
-        .then(actual => {throw {message: "failed"}})
-        .catch(err => {
+        .then(() => { throw new Error("failed"); })
+        .catch((err) => {
           expect(err.message).to.equal("unsupported datacontentencoding");
         });
     });
@@ -274,28 +268,28 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
     it("No error when 'ce-datacontentencoding' is base64", () => {
       // setup
       var payload = "eyJtdWNoIjoid293In0=";
-      let expected = {
-        much : "wow"
+      const expected = {
+        much: "wow"
       };
 
       var attributes = {
-        "ce-type"        : "type",
-        "ce-specversion" : "0.3",
-        "ce-source"      : "source",
-        "ce-id"          : "id",
-        "ce-time"        : "2019-06-16T11:42:00Z",
-        "ce-schemaurl"   : "http://schema.registry/v1",
-        "Content-Type"   : "application/json",
-        "ce-datacontentencoding" : "base64"
+        "ce-type": "type",
+        "ce-specversion": "0.3",
+        "ce-source": "source",
+        "ce-id": "id",
+        "ce-time": "2019-06-16T11:42:00Z",
+        "ce-schemaurl": "http://schema.registry/v1",
+        "Content-Type": "application/json",
+        "ce-datacontentencoding": "base64"
       };
 
       var un = new Unmarshaller();
 
       // act and assert
       return un.unmarshall(payload, attributes)
-        .then(actual => expect(actual.getData()).to.deep.equal(expected))
-        .catch(err => {
-          console.log(err);
+        .then((actual) => expect(actual.getData()).to.deep.equal(expected))
+        .catch((err) => {
+          console.error(err);
           throw err;
         });
     });

--- a/test/cloudevent_spec_0_1.js
+++ b/test/cloudevent_spec_0_1.js
@@ -1,22 +1,19 @@
-var expect       = require("chai").expect;
-var Cloudevent   = require("../index.js");
+var expect = require("chai").expect;
+var Cloudevent = require("../index.js");
 
-const type   = "com.github.pull.create01";
+const type = "com.github.pull.create01";
 const source = "urn:event:from:myapi/resourse/01";
-const time   = new Date();
+const time = new Date();
 const schemaurl = "http://example.com/registry/v01/myschema.json";
 const contenttype = "application/json";
 const data = {};
-const extensions = {};
 
 var cloudevent = new Cloudevent()
-                       .type(type)
-                       .source(source);
+  .type(type)
+  .source(source);
 
 describe("CloudEvents Spec 0.1 - JavaScript SDK", () => {
-
   describe("Object properties", () => {
-
     describe("Attribute getters", () => {
       it("returns 'type'", () => {
         expect(cloudevent.getType()).to.equal(type);
@@ -29,7 +26,6 @@ describe("CloudEvents Spec 0.1 - JavaScript SDK", () => {
   });
 
   describe("JSON Format", () => {
-
     describe("Required context attributes", () => {
       it("requires 'eventType'", () => {
         expect(cloudevent.format()).to.have.property("eventType");
@@ -84,7 +80,6 @@ describe("CloudEvents Spec 0.1 - JavaScript SDK", () => {
         expect(cloudevent.format().extensions)
           .to.have.property("foo");
       });
-
     });
 
     describe("The Constraints check", () => {
@@ -102,20 +97,18 @@ describe("CloudEvents Spec 0.1 - JavaScript SDK", () => {
         });
 
         it("should be prefixed with a reverse-DNS name", () => {
-          //TODO how to assert it?
+          // TODO how to assert it?
         });
       });
 
-      //TODO another attributes . . .
+      // TODO another attributes . . .
 
       describe("'eventTime'", () => {
         it("must adhere to the format specified in RFC 3339", () => {
           cloudevent.time(time);
-          expect(cloudevent.format()["eventTime"]).to.equal(time.toISOString());
+          expect(cloudevent.format().eventTime).to.equal(time.toISOString());
         });
       });
     });
-
   });
-
 });

--- a/test/cloudevent_spec_0_2.js
+++ b/test/cloudevent_spec_0_2.js
@@ -1,23 +1,20 @@
-var expect     = require("chai").expect;
+var expect = require("chai").expect;
 var Cloudevent = require("../index.js");
 
-const type   = "com.github.pull.create";
+const type = "com.github.pull.create";
 const source = "urn:event:from:myapi/resourse/123";
-const time   = new Date();
+const time = new Date();
 const schemaurl = "http://example.com/registry/myschema.json";
 const contenttype = "application/json";
 const data = {};
-const extensions = {};
 
 var cloudevent =
   new Cloudevent(Cloudevent.specs["0.2"])
-        .type(type)
-        .source(source);
+    .type(type)
+    .source(source);
 
 describe("CloudEvents Spec 0.2 - JavaScript SDK", () => {
-
   describe("Object properties", () => {
-
     describe("Attribute getters", () => {
       it("returns 'type'", () => {
         expect(cloudevent.getType()).to.equal(type);
@@ -30,7 +27,6 @@ describe("CloudEvents Spec 0.2 - JavaScript SDK", () => {
   });
 
   describe("JSON Format", () => {
-
     describe("Required context attributes", () => {
       it("requires 'type'", () => {
         expect(cloudevent.format()).to.have.property("type");
@@ -93,15 +89,14 @@ describe("CloudEvents Spec 0.2 - JavaScript SDK", () => {
 
       it("'extension2' should have value equals to 'value1'", () => {
         cloudevent.addExtension("extension2", "value2");
-        expect(cloudevent.format()["extension2"]).to.equal("value2");
+        expect(cloudevent.format().extension2).to.equal("value2");
       });
 
       it("should throw an error when employ reserved name as extension", () => {
-
         var cevt =
           new Cloudevent(Cloudevent.specs["0.2"])
-                .type(type)
-                .source(source);
+            .type(type)
+            .source(source);
         expect(cevt.addExtension.bind(cevt, "id"))
           .to
           .throw("Reserved attribute name: 'id'");
@@ -123,13 +118,13 @@ describe("CloudEvents Spec 0.2 - JavaScript SDK", () => {
         });
 
         it("should be prefixed with a reverse-DNS name", () => {
-          //TODO how to assert it?
+          // TODO how to assert it?
         });
       });
 
       describe("'specversion'", () => {
         it("compliant event producers must use a value of '0.2'", () => {
-          expect(cloudevent.format()["specversion"]).to.equal("0.2");
+          expect(cloudevent.format().specversion).to.equal("0.2");
         });
 
         it("should throw an error when is an empty string", () => {
@@ -165,10 +160,9 @@ describe("CloudEvents Spec 0.2 - JavaScript SDK", () => {
       describe("'time'", () => {
         it("must adhere to the format specified in RFC 3339", () => {
           cloudevent.time(time);
-          expect(cloudevent.format()["time"]).to.equal(time.toISOString());
+          expect(cloudevent.format().time).to.equal(time.toISOString());
         });
       });
     });
   });
-
 });

--- a/test/formats/json/parser_test.js
+++ b/test/formats/json/parser_test.js
@@ -2,12 +2,10 @@ var expect = require("chai").expect;
 var Parser = require("../../../lib/formats/json/parser.js");
 var Cloudevent = require("../../../index.js");
 
-const type        = "com.github.pull.create";
-const source      = "urn:event:from:myapi/resourse/123";
-const webhook     = "https://cloudevents.io/webhook";
-const contentType = "application/cloudevents+json; charset=utf-8";
-const now         = new Date();
-const schemaurl   = "http://cloudevents.io/schema.json";
+const type = "com.github.pull.create";
+const source = "urn:event:from:myapi/resourse/123";
+const now = new Date();
+const schemaurl = "http://cloudevents.io/schema.json";
 
 const ceContentType = "application/json";
 
@@ -16,7 +14,6 @@ const data = {
 };
 
 describe("JSON Event Format Parser", () => {
-
   it("Throw error when payload is an integer", () => {
     // setup
     var payload = 83;
@@ -24,7 +21,7 @@ describe("JSON Event Format Parser", () => {
 
     // act and assert
     expect(parser.parse.bind(parser, payload))
-        .to.throw("invalid payload type, allowed are: string or object");
+      .to.throw("invalid payload type, allowed are: string or object");
   });
 
   it("Throw error when payload is null", () => {
@@ -34,7 +31,7 @@ describe("JSON Event Format Parser", () => {
 
     // act and assert
     expect(parser.parse.bind(parser, payload))
-        .to.throw("null or undefined payload");
+      .to.throw("null or undefined payload");
   });
 
   it("Throw error when payload is undefined", () => {
@@ -43,7 +40,7 @@ describe("JSON Event Format Parser", () => {
 
     // act and assert
     expect(parser.parse.bind(parser))
-        .to.throw("null or undefined payload");
+      .to.throw("null or undefined payload");
   });
 
   it("Throw error when payload is a float", () => {
@@ -53,7 +50,7 @@ describe("JSON Event Format Parser", () => {
 
     // act and assert
     expect(parser.parse.bind(parser, payload))
-        .to.throw("invalid payload type, allowed are: string or object");
+      .to.throw("invalid payload type, allowed are: string or object");
   });
 
   it("Throw error when payload is an invalid JSON", () => {
@@ -63,7 +60,7 @@ describe("JSON Event Format Parser", () => {
 
     // act and assert
     expect(parser.parse.bind(parser, payload))
-        .to.throw("Unexpected token g in JSON at position 0");
+      .to.throw("Unexpected token g in JSON at position 0");
   });
 
   it("Must accept the CloudEvent spec 0.2 as JSON", () => {
@@ -85,7 +82,7 @@ describe("JSON Event Format Parser", () => {
 
     // assert
     expect(actual)
-        .to.be.an("object");
+      .to.be.an("object");
   });
 
   it("Must accept when the payload is a string well formed as JSON", () => {
@@ -98,6 +95,6 @@ describe("JSON Event Format Parser", () => {
 
     // assert
     expect(actual)
-        .to.be.an("object");
+      .to.be.an("object");
   });
 });

--- a/test/fun_tests.js
+++ b/test/fun_tests.js
@@ -4,13 +4,13 @@ const fun = require("../lib/utils/fun.js");
 describe("Functional approach", () => {
   describe("isStringOrThrow", () => {
     it("should throw when is not a string", () => {
-      expect(fun.isStringOrThrow.bind(fun, 3.6, {message: "works!"}))
+      expect(fun.isStringOrThrow.bind(fun, 3.6, { message: "works!" }))
         .to
         .throw("works!");
     });
 
     it("should return true when is a string", () => {
-      expect(fun.isStringOrThrow("cool", {message: "not throws!"}))
+      expect(fun.isStringOrThrow("cool", { message: "not throws!" }))
         .to
         .equals(true);
     });
@@ -18,13 +18,13 @@ describe("Functional approach", () => {
 
   describe("equalsOrThrow", () => {
     it("should throw when they are not equals", () => {
-      expect(fun.equalsOrThrow.bind(fun, "z", "a", {message: "works!"}))
+      expect(fun.equalsOrThrow.bind(fun, "z", "a", { message: "works!" }))
         .to
         .throw("works!");
     });
 
     it("should return true when they are equals", () => {
-      expect(fun.equalsOrThrow("z", "z", {message: "not throws!"}))
+      expect(fun.equalsOrThrow("z", "z", { message: "not throws!" }))
         .to
         .equals(true);
     });
@@ -32,21 +32,21 @@ describe("Functional approach", () => {
 
   describe("isBase64", () => {
     it("should return false when is not base64 string", () => {
-      let actual = fun.isBase64("non base 64");
+      const actual = fun.isBase64("non base 64");
 
       expect(actual).to.equal(false);
     });
 
     it("should return true when is a base64 string", () => {
-      let actual = fun.isBase64("Y2xvdWRldmVudHMK");
+      const actual = fun.isBase64("Y2xvdWRldmVudHMK");
 
       expect(actual).to.equal(true);
     });
   });
 
-  describe("asData" , () => {
+  describe("asData", () => {
     it("should throw error when data is not a valid json", () => {
-      let data = "not a json";
+      const data = "not a json";
 
       expect(fun.asData.bind(fun, data, "application/json"))
         .to
@@ -54,37 +54,37 @@ describe("Functional approach", () => {
     });
 
     it("should parse string content type as string", () => {
-      let expected = "a string";
+      const expected = "a string";
 
-      let actual = fun.asData(expected, "text/plain");
+      const actual = fun.asData(expected, "text/plain");
 
       expect((typeof actual)).to.equal("string");
       expect(actual).to.equal(expected);
     });
 
     it("should parse 'application/json' as json object", () => {
-      let expected = {
+      const expected = {
         much: "wow",
-        myext : {
-          ext : "x04"
+        myext: {
+          ext: "x04"
         }
       };
 
-      let actual = fun.asData(JSON.stringify(expected), "application/json");
+      const actual = fun.asData(JSON.stringify(expected), "application/json");
 
       expect((typeof actual)).to.equal("object");
       expect(actual).to.deep.equal(expected);
     });
 
     it("should parse 'application/cloudevents+json' as json object", () => {
-      let expected = {
+      const expected = {
         much: "wow",
-        myext : {
-          ext : "x04"
+        myext: {
+          ext: "x04"
         }
       };
 
-      let actual = fun.asData(JSON.stringify(expected),
+      const actual = fun.asData(JSON.stringify(expected),
         "application/cloudevents+json");
 
       expect((typeof actual)).to.equal("object");
@@ -92,14 +92,14 @@ describe("Functional approach", () => {
     });
 
     it("should parse 'text/json' as json object", () => {
-      let expected = {
+      const expected = {
         much: "wow",
-        myext : {
-          ext : "x04"
+        myext: {
+          ext: "x04"
         }
       };
 
-      let actual = fun.asData(JSON.stringify(expected),
+      const actual = fun.asData(JSON.stringify(expected),
         "text/json");
 
       expect((typeof actual)).to.equal("object");

--- a/test/http_binding_0_1.js
+++ b/test/http_binding_0_1.js
@@ -1,13 +1,13 @@
-var expect       = require("chai").expect;
-var Cloudevent   = require("../index.js");
-var nock         = require("nock");
+var expect = require("chai").expect;
+var Cloudevent = require("../index.js");
+var nock = require("nock");
 
-const type        = "com.github.pull.create";
-const source      = "urn:event:from:myapi/resourse/123";
-const webhook     = "https://cloudevents.io/webhook";
+const type = "com.github.pull.create";
+const source = "urn:event:from:myapi/resourse/123";
+const webhook = "https://cloudevents.io/webhook";
 const contentType = "application/cloudevents+json; charset=utf-8";
-const now         = new Date();
-const schemaurl   = "http://cloudevents.io/schema.json";
+const now = new Date();
+const schemaurl = "http://cloudevents.io/schema.json";
 
 const ceContentType = "application/json";
 
@@ -15,13 +15,13 @@ const data = {
   foo: "bar"
 };
 
-const ext1Name  = "extension1";
+const ext1Name = "extension1";
 const ext1Value = "foobar";
-const ext2Name  = "extension2";
+const ext2Name = "extension2";
 const ext2Value = "acme";
 
 const Structured01 = Cloudevent.bindings["http-structured0.1"];
-const Binary01     = Cloudevent.bindings["http-binary0.1"];
+const Binary01 = Cloudevent.bindings["http-binary0.1"];
 
 var cloudevent =
   new Cloudevent()
@@ -37,122 +37,109 @@ var cloudevent =
 cloudevent.eventTypeVersion("1.0.0");
 
 var httpcfg = {
-  method : "POST",
-  url    : webhook + "/json"
+  method: "POST",
+  url: `${webhook}/json`
 };
 
 var httpstructured01 = new Structured01(httpcfg);
-var httpbinary01     = new Binary01(httpcfg);
+var httpbinary01 = new Binary01(httpcfg);
 
 describe("HTTP Transport Binding - Version 0.1", () => {
   beforeEach(() => {
     // Mocking the webhook
     nock(webhook)
       .post("/json")
-      .reply(201, {status: "accepted"});
+      .reply(201, { status: "accepted" });
   });
 
   describe("Structured", () => {
     describe("JSON Format", () => {
-      it("requires '" + contentType + "' Content-Type in the header", () => {
-        return httpstructured01.emit(cloudevent)
+      it(`requires '${contentType}' Content-Type in the header`,
+        () => httpstructured01.emit(cloudevent)
           .then((response) => {
             expect(response.config.headers["Content-Type"])
               .to.equal(contentType);
-          });
-      });
+          }));
 
-      it("the request payload should be correct", () => {
-        return httpstructured01.emit(cloudevent)
+      it("the request payload should be correct",
+        () => httpstructured01.emit(cloudevent)
           .then((response) => {
             expect(JSON.parse(response.config.data))
               .to.deep.equal(cloudevent.format());
-          });
-      });
+          }));
     });
   });
 
   describe("Binary", () => {
     describe("JSON Format", () => {
-      it("requires '" + cloudevent.getContenttype() + "' Content-Type in the header", () => {
-        return httpbinary01.emit(cloudevent)
+      it(`requires '${cloudevent.getContenttype()}' Content-Type in the header`,
+        () => httpbinary01.emit(cloudevent)
           .then((response) => {
             expect(response.config.headers["Content-Type"])
               .to.equal(cloudevent.getContenttype());
-          });
-      });
+          }));
 
-      it("the request payload should be correct", () => {
-        return httpbinary01.emit(cloudevent)
+      it("the request payload should be correct",
+        () => httpbinary01.emit(cloudevent)
           .then((response) => {
             expect(JSON.parse(response.config.data))
               .to.deep.equal(cloudevent.getData());
-          });
-      });
+          }));
 
-      it("HTTP Header contains 'CE-EventType'", () => {
-        return httpbinary01.emit(cloudevent)
+      it("HTTP Header contains 'CE-EventType'",
+        () => httpbinary01.emit(cloudevent)
           .then((response) => {
             expect(response.config.headers)
               .to.have.property("CE-EventType");
-          });
-      });
+          }));
 
-      it("HTTP Header contains 'CE-EventTypeVersion'", () => {
-        return httpbinary01.emit(cloudevent)
+      it("HTTP Header contains 'CE-EventTypeVersion'",
+        () => httpbinary01.emit(cloudevent)
           .then((response) => {
             expect(response.config.headers)
               .to.have.property("CE-EventTypeVersion");
-          });
-      });
+          }));
 
-      it("HTTP Header contains 'CE-CloudEventsVersion'", () => {
-        return httpbinary01.emit(cloudevent)
+      it("HTTP Header contains 'CE-CloudEventsVersion'",
+        () => httpbinary01.emit(cloudevent)
           .then((response) => {
             expect(response.config.headers)
               .to.have.property("CE-CloudEventsVersion");
-          });
-      });
+          }));
 
-      it("HTTP Header contains 'CE-Source'", () => {
-        return httpbinary01.emit(cloudevent)
-          .then((response) => {
-            expect(response.config.headers)
-              .to.have.property("CE-Source");
-          });
-      });
+      it("HTTP Header contains 'CE-Source'", () => httpbinary01.emit(cloudevent)
+        .then((response) => {
+          expect(response.config.headers)
+            .to.have.property("CE-Source");
+        }));
 
-      it("HTTP Header contains 'CE-EventID'", () => {
-        return httpbinary01.emit(cloudevent)
+      it("HTTP Header contains 'CE-EventID'",
+        () => httpbinary01.emit(cloudevent)
           .then((response) => {
             expect(response.config.headers)
               .to.have.property("CE-EventID");
-          });
-      });
+          }));
 
-      it("HTTP Header contains 'CE-EventTime'", () => {
-        return httpbinary01.emit(cloudevent)
+      it("HTTP Header contains 'CE-EventTime'",
+        () => httpbinary01.emit(cloudevent)
           .then((response) => {
             expect(response.config.headers)
               .to.have.property("CE-EventTime");
-          });
-      });
+          }));
 
-      it("HTTP Header contains 'CE-SchemaURL'", () => {
-        return httpbinary01.emit(cloudevent)
+      it("HTTP Header contains 'CE-SchemaURL'",
+        () => httpbinary01.emit(cloudevent)
           .then((response) => {
             expect(response.config.headers)
               .to.have.property("CE-SchemaURL");
-          });
-      });
+          }));
 
-      it("HTTP Header contains 'CE-X-Extension1' as extension", () => {
-        return httpbinary01.emit(cloudevent)
+      it("HTTP Header contains 'CE-X-Extension1' as extension",
+        () => httpbinary01.emit(cloudevent)
           .then((response) => {
             expect(response.config.headers)
               .to.have.property("CE-X-Extension1");
-          });
-      });
+          }));
     });
   });
 });

--- a/test/http_binding_0_2.js
+++ b/test/http_binding_0_2.js
@@ -1,16 +1,13 @@
 var expect = require("chai").expect;
 var Cloudevent = require("../index.js");
 var nock = require("nock");
-var Spec02 = require("../lib/specs/spec_0_2.js");
 
-var {HTTPBinary02} = require("../lib/bindings/http/emitter_binary_0_2.js");
-
-const type        = "com.github.pull.create";
-const source      = "urn:event:from:myapi/resourse/123";
-const webhook     = "https://cloudevents.io/webhook";
+const type = "com.github.pull.create";
+const source = "urn:event:from:myapi/resourse/123";
+const webhook = "https://cloudevents.io/webhook";
 const contentType = "application/cloudevents+json; charset=utf-8";
-const now         = new Date();
-const schemaurl   = "http://cloudevents.io/schema.json";
+const now = new Date();
+const schemaurl = "http://cloudevents.io/schema.json";
 
 const ceContentType = "application/json";
 
@@ -18,19 +15,13 @@ const data = {
   foo: "bar"
 };
 
-const ext1Name  = "extension1";
+const ext1Name = "extension1";
 const ext1Value = "foobar";
-const ext2Name  = "extension2";
+const ext2Name = "extension2";
 const ext2Value = "acme";
 
-const receiverConfig = {
-  path   : "/events",
-  port   : 10300,
-  method : "POST"
-};
-
 const Structured02 = Cloudevent.bindings["http-structured0.2"];
-const Binary02     = Cloudevent.bindings["http-binary0.2"];
+const Binary02 = Cloudevent.bindings["http-binary0.2"];
 
 var cloudevent =
   new Cloudevent()
@@ -44,122 +35,106 @@ var cloudevent =
     .addExtension(ext2Name, ext2Value);
 
 var httpcfg = {
-  method : "POST",
-  url    : webhook + "/json"
+  method: "POST",
+  url: `${webhook}/json`
 };
 
 var httpstructured02 = new Structured02(httpcfg);
-var httpbinary02     = new Binary02(httpcfg);
+var httpbinary02 = new Binary02(httpcfg);
 
 describe("HTTP Transport Binding - Version 0.2", () => {
   beforeEach(() => {
     // Mocking the webhook
     nock(webhook)
       .post("/json")
-      .reply(201, {status: "accepted"});
+      .reply(201, { status: "accepted" });
   });
 
   describe("Structured", () => {
     describe("JSON Format", () => {
-      it("requires '" + contentType + "' Content-Type in the header", () => {
-        return httpstructured02.emit(cloudevent)
+      it(`requires '${contentType}' Content-Type in the header`,
+        () => httpstructured02.emit(cloudevent)
           .then((response) => {
             expect(response.config.headers["Content-Type"])
               .to.equal(contentType);
-          });
-      });
+          }));
 
-      it("the request payload should be correct", () => {
-        return httpstructured02.emit(cloudevent)
+      it("the request payload should be correct",
+        () => httpstructured02.emit(cloudevent)
           .then((response) => {
             expect(JSON.parse(response.config.data))
               .to.deep.equal(cloudevent.format());
-          });
-      });
+          }));
     });
   });
 
   describe("Binary", () => {
     describe("JSON Format", () => {
-      it("requires '" + cloudevent.getContenttype() + "' Content-Type in the header", () => {
-        return httpbinary02.emit(cloudevent)
+      it(`requires ${cloudevent.getContenttype()} Content-Type in the header`,
+        () => httpbinary02.emit(cloudevent)
           .then((response) => {
             expect(response.config.headers["Content-Type"])
               .to.equal(cloudevent.getContenttype());
-          });
-      });
+          }));
 
-      it("the request payload should be correct", () => {
-        return httpbinary02.emit(cloudevent)
+      it("the request payload should be correct",
+        () => httpbinary02.emit(cloudevent)
           .then((response) => {
             expect(JSON.parse(response.config.data))
               .to.deep.equal(cloudevent.getData());
-          });
-      });
+          }));
 
-      it("HTTP Header contains 'ce-type'", () => {
-        return httpbinary02.emit(cloudevent)
-          .then((response) => {
-            expect(response.config.headers)
-              .to.have.property("ce-type");
-          });
-      });
+      it("HTTP Header contains 'ce-type'", () => httpbinary02.emit(cloudevent)
+        .then((response) => {
+          expect(response.config.headers)
+            .to.have.property("ce-type");
+        }));
 
-      it("HTTP Header contains 'ce-specversion'", () => {
-        return httpbinary02.emit(cloudevent)
+      it("HTTP Header contains 'ce-specversion'",
+        () => httpbinary02.emit(cloudevent)
           .then((response) => {
             expect(response.config.headers)
               .to.have.property("ce-specversion");
-          });
-      });
+          }));
 
-      it("HTTP Header contains 'ce-source'", () => {
-        return httpbinary02.emit(cloudevent)
-          .then((response) => {
-            expect(response.config.headers)
-              .to.have.property("ce-source");
-          });
-      });
+      it("HTTP Header contains 'ce-source'", () => httpbinary02.emit(cloudevent)
+        .then((response) => {
+          expect(response.config.headers)
+            .to.have.property("ce-source");
+        }));
 
-      it("HTTP Header contains 'ce-id'", () => {
-        return httpbinary02.emit(cloudevent)
-          .then((response) => {
-            expect(response.config.headers)
-              .to.have.property("ce-id");
-          });
-      });
+      it("HTTP Header contains 'ce-id'", () => httpbinary02.emit(cloudevent)
+        .then((response) => {
+          expect(response.config.headers)
+            .to.have.property("ce-id");
+        }));
 
-      it("HTTP Header contains 'ce-time'", () => {
-        return httpbinary02.emit(cloudevent)
-          .then((response) => {
-            expect(response.config.headers)
-              .to.have.property("ce-time");
-          });
-      });
+      it("HTTP Header contains 'ce-time'", () => httpbinary02.emit(cloudevent)
+        .then((response) => {
+          expect(response.config.headers)
+            .to.have.property("ce-time");
+        }));
 
-      it("HTTP Header contains 'ce-schemaurl'", () => {
-        return httpbinary02.emit(cloudevent)
+      it("HTTP Header contains 'ce-schemaurl'",
+        () => httpbinary02.emit(cloudevent)
           .then((response) => {
             expect(response.config.headers)
               .to.have.property("ce-schemaurl");
-          });
-      });
+          }));
 
-      it("HTTP Header contains 'ce-" + ext1Name + "'", () => {
-        return httpbinary02.emit(cloudevent)
+      it(`HTTP Header contains 'ce-${ext1Name}'`,
+        () => httpbinary02.emit(cloudevent)
           .then((response) => {
             expect(response.config.headers)
-              .to.have.property("ce-" + ext1Name);
-          });
-      });
+              .to.have.property(`ce-${ext1Name}`);
+          }));
 
-      it("HTTP Header contains 'ce-" + ext2Name + "'", () => {
-        return httpbinary02.emit(cloudevent)
+      it(`HTTP Header contains 'ce-${ext2Name}'`,
+        () => httpbinary02.emit(cloudevent)
           .then((response) => {
             expect(response.config.headers)
-              .to.have.property("ce-" + ext2Name);
-          });
-      });
+              .to.have.property(`ce-${ext2Name}`);
+          }));
     });
   });
 });

--- a/test/http_binding_0_3.js
+++ b/test/http_binding_0_3.js
@@ -5,12 +5,12 @@ const BinaryHTTPEmitter =
 const Cloudevent = require("../lib/cloudevent.js");
 const v03 = require("../v03/index.js");
 
-const type        = "com.github.pull.create";
-const source      = "urn:event:from:myapi/resourse/123";
+const type = "com.github.pull.create";
+const source = "urn:event:from:myapi/resourse/123";
 const contentEncoding = "base64";
 const contentType = "application/cloudevents+json; charset=utf-8";
-const now         = new Date();
-const schemaurl   = "http://cloudevents.io/schema.json";
+const now = new Date();
+const schemaurl = "http://cloudevents.io/schema.json";
 
 const ceContentType = "application/json";
 
@@ -19,9 +19,9 @@ const data = {
 };
 const dataBase64 = "Y2xvdWRldmVudHMK";
 
-const ext1Name  = "extension1";
+const ext1Name = "extension1";
 const ext1Value = "foobar";
-const ext2Name  = "extension2";
+const ext2Name = "extension2";
 const ext2Value = "acme";
 
 const cloudevent =
@@ -48,11 +48,10 @@ const cebase64 =
     .addExtension(ext1Name, ext1Value)
     .addExtension(ext2Name, ext2Value);
 
-
 const webhook = "https://cloudevents.io/webhook";
 const httpcfg = {
-  method : "POST",
-  url    : webhook + "/json"
+  method: "POST",
+  url: `${webhook}/json`
 };
 
 const binary = new BinaryHTTPEmitter(httpcfg);
@@ -63,219 +62,180 @@ describe("HTTP Transport Binding - Version 0.3", () => {
     // Mocking the webhook
     nock(webhook)
       .post("/json")
-      .reply(201, {status: "accepted"});
+      .reply(201, { status: "accepted" });
   });
 
   describe("Structured", () => {
     describe("JSON Format", () => {
-      it("requires '" + contentType + "' Content-Type in the header", () => {
-        return structured.emit(cloudevent)
+      it(`requires '${contentType}' Content-Type in the header`,
+        () => structured.emit(cloudevent)
           .then((response) => {
             expect(response.config.headers["Content-Type"])
               .to.equal(contentType);
-          });
-      });
+          }));
 
-      it("the request payload should be correct", () => {
-        return structured.emit(cloudevent)
+      it("the request payload should be correct",
+        () => structured.emit(cloudevent)
           .then((response) => {
             expect(JSON.parse(response.config.data))
               .to.deep.equal(cloudevent.format());
-          });
-      });
+          }));
 
       describe("'data' attribute with 'base64' encoding", () => {
-        it("the request payload should be correct", () => {
-          return structured.emit(cebase64)
+        it("the request payload should be correct",
+          () => structured.emit(cebase64)
             .then((response) => {
               expect(JSON.parse(response.config.data).data)
                 .to.equal(cebase64.format().data);
-            });
-        });
+            }));
       });
     });
   });
 
   describe("Binary", () => {
     describe("JSON Format", () => {
-      it("requires '" + cloudevent.getDataContentType() + "' Content-Type in the header", () => {
-        return binary.emit(cloudevent)
+      it(`requires ${cloudevent.getDataContentType()} in the header`,
+        () => binary.emit(cloudevent)
           .then((response) => {
             expect(response.config.headers["Content-Type"])
               .to.equal(cloudevent.getDataContentType());
-          });
-      });
+          }));
 
-      it("the request payload should be correct", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(JSON.parse(response.config.data))
-              .to.deep.equal(cloudevent.getData());
-          });
-      });
+      it("the request payload should be correct", () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(JSON.parse(response.config.data))
+            .to.deep.equal(cloudevent.getData());
+        }));
 
-      it("HTTP Header contains 'ce-type'", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(response.config.headers)
-              .to.have.property("ce-type");
-          });
-      });
+      it("HTTP Header contains 'ce-type'", () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(response.config.headers)
+            .to.have.property("ce-type");
+        }));
 
-      it("HTTP Header contains 'ce-specversion'", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(response.config.headers)
-              .to.have.property("ce-specversion");
-          });
-      });
+      it("HTTP Header contains 'ce-specversion'", () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(response.config.headers)
+            .to.have.property("ce-specversion");
+        }));
 
-      it("HTTP Header contains 'ce-source'", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(response.config.headers)
-              .to.have.property("ce-source");
-          });
-      });
+      it("HTTP Header contains 'ce-source'", () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(response.config.headers)
+            .to.have.property("ce-source");
+        }));
 
-      it("HTTP Header contains 'ce-id'", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(response.config.headers)
-              .to.have.property("ce-id");
-          });
-      });
+      it("HTTP Header contains 'ce-id'", () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(response.config.headers)
+            .to.have.property("ce-id");
+        }));
 
-      it("HTTP Header contains 'ce-time'", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(response.config.headers)
-              .to.have.property("ce-time");
-          });
-      });
+      it("HTTP Header contains 'ce-time'", () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(response.config.headers)
+            .to.have.property("ce-time");
+        }));
 
-      it("HTTP Header contains 'ce-schemaurl'", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(response.config.headers)
-              .to.have.property("ce-schemaurl");
-          });
-      });
+      it("HTTP Header contains 'ce-schemaurl'", () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(response.config.headers)
+            .to.have.property("ce-schemaurl");
+        }));
 
-      it("HTTP Header contains 'ce-" + ext1Name + "'", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(response.config.headers)
-              .to.have.property("ce-" + ext1Name);
-          });
-      });
+      it(`HTTP Header contains 'ce-${ext1Name}'`, () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(response.config.headers)
+            .to.have.property(`ce-${ext1Name}`);
+        }));
 
-      it("HTTP Header contains 'ce-" + ext2Name + "'", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(response.config.headers)
-              .to.have.property("ce-" + ext2Name);
-          });
-      });
+      it(`HTTP Header contains 'ce-${ext2Name}'`, () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(response.config.headers)
+            .to.have.property(`ce-${ext2Name}`);
+        }));
 
-      it("HTTP Header contains 'ce-subject'", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(response.config.headers)
-              .to.have.property("ce-subject");
-          });
-      });
+      it("HTTP Header contains 'ce-subject'", () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(response.config.headers)
+            .to.have.property("ce-subject");
+        }));
 
-      it("should 'ce-type' have the right value", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(cloudevent.getType())
-              .to.equal(response.config.headers["ce-type"]);
-          });
-      });
+      it("should 'ce-type' have the right value", () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(cloudevent.getType())
+            .to.equal(response.config.headers["ce-type"]);
+        }));
 
-      it("should 'ce-specversion' have the right value", () => {
-        return binary.emit(cloudevent)
+      it("should 'ce-specversion' have the right value",
+        () => binary.emit(cloudevent)
           .then((response) => {
             expect(cloudevent.getSpecversion())
               .to.equal(response.config.headers["ce-specversion"]);
-          });
-      });
+          }));
 
-      it("should 'ce-source' have the right value", () => {
-        return binary.emit(cloudevent)
+      it("should 'ce-source' have the right value",
+        () => binary.emit(cloudevent)
           .then((response) => {
             expect(cloudevent.getSource())
               .to.equal(response.config.headers["ce-source"]);
-          });
-      });
+          }));
 
-      it("should 'ce-id' have the right value", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(cloudevent.getId())
-              .to.equal(response.config.headers["ce-id"]);
-          });
-      });
+      it("should 'ce-id' have the right value", () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(cloudevent.getId())
+            .to.equal(response.config.headers["ce-id"]);
+        }));
 
-      it("should 'ce-time' have the right value", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(cloudevent.getTime())
-              .to.equal(response.config.headers["ce-time"]);
-          });
-      });
+      it("should 'ce-time' have the right value", () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(cloudevent.getTime())
+            .to.equal(response.config.headers["ce-time"]);
+        }));
 
-      it("should 'ce-schemaurl' have the right value", () => {
-        return binary.emit(cloudevent)
+      it("should 'ce-schemaurl' have the right value",
+        () => binary.emit(cloudevent)
           .then((response) => {
             expect(cloudevent.getSchemaurl())
               .to.equal(response.config.headers["ce-schemaurl"]);
-          });
-      });
+          }));
 
-      it("should 'ce-" + ext1Name + "' have the right value", () => {
-        return binary.emit(cloudevent)
+      it(`should 'ce-${ext1Name}' have the right value`,
+        () => binary.emit(cloudevent)
           .then((response) => {
             expect(cloudevent.getExtensions()[ext1Name])
-              .to.equal(response.config.headers["ce-" + ext1Name]);
-          });
-      });
+              .to.equal(response.config.headers[`ce-${ext1Name}`]);
+          }));
 
-      it("should 'ce-" + ext2Name + "' have the right value", () => {
-        return binary.emit(cloudevent)
+      it(`should 'ce-${ext2Name}' have the right value`,
+        () => binary.emit(cloudevent)
           .then((response) => {
             expect(cloudevent.getExtensions()[ext2Name])
-              .to.equal(response.config.headers["ce-" + ext2Name]);
-          });
-      });
+              .to.equal(response.config.headers[`ce-${ext2Name}`]);
+          }));
 
-      it("should 'ce-subject' have the right value", () => {
-        return binary.emit(cloudevent)
+      it("should 'ce-subject' have the right value",
+        () => binary.emit(cloudevent)
           .then((response) => {
             expect(cloudevent.getSubject())
               .to.equal(response.config.headers["ce-subject"]);
-          });
-      });
+          }));
 
       describe("'data' attribute with 'base64' encoding", () => {
-        it("HTTP Header contains 'ce-datacontentencoding'", () => {
-          return binary.emit(cebase64)
+        it("HTTP Header contains 'ce-datacontentencoding'",
+          () => binary.emit(cebase64)
             .then((response) => {
               expect(response.config.headers)
                 .to.have.property("ce-datacontentencoding");
-            });
-        });
+            }));
 
-        it("should 'ce-datacontentencoding' have the right value", () => {
-          return binary.emit(cloudevent)
+        it("should 'ce-datacontentencoding' have the right value",
+          () => binary.emit(cloudevent)
             .then((response) => {
               expect(cloudevent.getDataContentEncoding())
                 .to.equal(response.config.headers["ce-datacontentencoding"]);
-            });
-        });
+            }));
       });
     });
   });
-
 });

--- a/test/http_binding_1.js
+++ b/test/http_binding_1.js
@@ -1,7 +1,7 @@
 const expect = require("chai").expect;
 const nock = require("nock");
 const https = require("https");
-const {asBase64} = require("../lib/utils/fun.js");
+const { asBase64 } = require("../lib/utils/fun.js");
 
 const {
   Spec,
@@ -10,11 +10,11 @@ const {
   Cloudevent
 } = require("../v1/index.js");
 
-const type        = "com.github.pull.create";
-const source      = "urn:event:from:myapi/resourse/123";
+const type = "com.github.pull.create";
+const source = "urn:event:from:myapi/resourse/123";
 const contentType = "application/cloudevents+json; charset=utf-8";
-const now         = new Date();
-const dataschema  = "http://cloudevents.io/schema.json";
+const now = new Date();
+const dataschema = "http://cloudevents.io/schema.json";
 
 const ceContentType = "application/json";
 
@@ -22,9 +22,9 @@ const data = {
   foo: "bar"
 };
 
-const ext1Name  = "extension1";
+const ext1Name = "extension1";
 const ext1Value = "foobar";
-const ext2Name  = "extension2";
+const ext2Name = "extension2";
 const ext2Value = "acme";
 
 const cloudevent =
@@ -39,12 +39,12 @@ const cloudevent =
     .addExtension(ext1Name, ext1Value)
     .addExtension(ext2Name, ext2Value);
 
-const dataString = ")(*~^my data for ce#@#$%"
+const dataString = ")(*~^my data for ce#@#$%";
 
 const webhook = "https://cloudevents.io/webhook/v1";
 const httpcfg = {
-  method : "POST",
-  url    : webhook + "/json"
+  method: "POST",
+  url: `${webhook}/json`
 };
 
 const binary = new BinaryHTTPEmitter(httpcfg);
@@ -55,47 +55,45 @@ describe("HTTP Transport Binding - Version 1.0", () => {
     // Mocking the webhook
     nock(webhook)
       .post("/json")
-      .reply(201, {status: "accepted"});
+      .reply(201, { status: "accepted" });
   });
 
   describe("Structured", () => {
-    it('works with mTLS authentication', () => {
+    it("works with mTLS authentication", () => {
       const event = new StructuredHTTPEmitter({
-        method: 'POST',
+        method: "POST",
         url: `${webhook}/json`,
         httpsAgent: new https.Agent({
-          cert: 'some value',
-          key: 'other value'
+          cert: "some value",
+          key: "other value"
         })
-      })
-      return event.emit(cloudevent).then(response => {
-        expect(response.config.headers['Content-Type'])
+      });
+      return event.emit(cloudevent).then((response) => {
+        expect(response.config.headers["Content-Type"])
           .to.equal(contentType);
       });
     });
 
     describe("JSON Format", () => {
-      it("requires '" + contentType + "' Content-Type in the header", () => {
-        return structured.emit(cloudevent)
+      it(`requires '${contentType}' Content-Type in the header`,
+        () => structured.emit(cloudevent)
           .then((response) => {
             expect(response.config.headers["Content-Type"])
               .to.equal(contentType);
-          });
-      });
+          }));
 
-      it("the request payload should be correct", () => {
-        return structured.emit(cloudevent)
+      it("the request payload should be correct",
+        () => structured.emit(cloudevent)
           .then((response) => {
             expect(JSON.parse(response.config.data))
               .to.deep.equal(cloudevent.format());
-          });
-      });
+          }));
 
       describe("Binary event data", () => {
         it("the request payload should be correct when data is binary", () => {
-          let bindata = Uint32Array.from(dataString, (c) => c.codePointAt(0));
-          let expected = asBase64(bindata);
-          let binevent =
+          const bindata = Uint32Array.from(dataString, (c) => c.codePointAt(0));
+          const expected = asBase64(bindata);
+          const binevent =
             new Cloudevent(Spec)
               .type(type)
               .source(source)
@@ -112,7 +110,7 @@ describe("HTTP Transport Binding - Version 1.0", () => {
         });
 
         it("the payload must have 'data_base64' when data is binary", () => {
-          let binevent =
+          const binevent =
             new Cloudevent(Spec)
               .type(type)
               .source(source)
@@ -132,42 +130,40 @@ describe("HTTP Transport Binding - Version 1.0", () => {
   });
 
   describe("Binary", () => {
-    it('works with mTLS authentication', () => {
+    it("works with mTLS authentication", () => {
       const event = new BinaryHTTPEmitter({
-        method: 'POST',
+        method: "POST",
         url: `${webhook}/json`,
         httpsAgent: new https.Agent({
-          cert: 'some value',
-          key: 'other value'
+          cert: "some value",
+          key: "other value"
         })
-      })
-      return event.emit(cloudevent).then(response => {
-        expect(response.config.headers['Content-Type'])
+      });
+      return event.emit(cloudevent).then((response) => {
+        expect(response.config.headers["Content-Type"])
           .to.equal(cloudevent.getDataContentType());
       });
     });
 
     describe("JSON Format", () => {
-      it("requires '" + cloudevent.getDataContentType() + "' Content-Type in the header", () => {
-        return binary.emit(cloudevent)
+      it(`requires '${cloudevent.getDataContentType()}' in the header`,
+        () => binary.emit(cloudevent)
           .then((response) => {
             expect(response.config.headers["Content-Type"])
               .to.equal(cloudevent.getDataContentType());
-          });
-      });
+          }));
 
-      it("the request payload should be correct", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(JSON.parse(response.config.data))
-              .to.deep.equal(cloudevent.getData());
-          });
-      });
+      it("the request payload should be correct", () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(JSON.parse(response.config.data))
+            .to.deep.equal(cloudevent.getData());
+        }));
 
-      it("the request payload should be correct when event data is binary", () => {
-        let bindata = Uint32Array.from(dataString, (c) => c.codePointAt(0));
-        let expected = asBase64(bindata);
-        let binevent =
+      it("the request payload should be correct when event data is binary",
+        () => {
+          const bindata = Uint32Array.from(dataString, (c) => c.codePointAt(0));
+          const expected = asBase64(bindata);
+          const binevent =
           new Cloudevent(Spec)
             .type(type)
             .source(source)
@@ -176,156 +172,126 @@ describe("HTTP Transport Binding - Version 1.0", () => {
             .addExtension(ext1Name, ext1Value)
             .addExtension(ext2Name, ext2Value);
 
-        return binary.emit(binevent)
-          .then((response) => {
-            expect(response.config.data)
-              .to.equal(expected);
-          });
-      });
+          return binary.emit(binevent)
+            .then((response) => {
+              expect(response.config.data)
+                .to.equal(expected);
+            });
+        });
 
-      it("HTTP Header contains 'ce-type'", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(response.config.headers)
-              .to.have.property("ce-type");
-          });
-      });
+      it("HTTP Header contains 'ce-type'", () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(response.config.headers)
+            .to.have.property("ce-type");
+        }));
 
-      it("HTTP Header contains 'ce-specversion'", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(response.config.headers)
-              .to.have.property("ce-specversion");
-          });
-      });
+      it("HTTP Header contains 'ce-specversion'", () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(response.config.headers)
+            .to.have.property("ce-specversion");
+        }));
 
-      it("HTTP Header contains 'ce-source'", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(response.config.headers)
-              .to.have.property("ce-source");
-          });
-      });
+      it("HTTP Header contains 'ce-source'", () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(response.config.headers)
+            .to.have.property("ce-source");
+        }));
 
-      it("HTTP Header contains 'ce-id'", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(response.config.headers)
-              .to.have.property("ce-id");
-          });
-      });
+      it("HTTP Header contains 'ce-id'", () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(response.config.headers)
+            .to.have.property("ce-id");
+        }));
 
-      it("HTTP Header contains 'ce-time'", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(response.config.headers)
-              .to.have.property("ce-time");
-          });
-      });
+      it("HTTP Header contains 'ce-time'", () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(response.config.headers)
+            .to.have.property("ce-time");
+        }));
 
-      it("HTTP Header contains 'ce-dataschema'", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(response.config.headers)
-              .to.have.property("ce-dataschema");
-          });
-      });
+      it("HTTP Header contains 'ce-dataschema'", () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(response.config.headers)
+            .to.have.property("ce-dataschema");
+        }));
 
-      it("HTTP Header contains 'ce-" + ext1Name + "'", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(response.config.headers)
-              .to.have.property("ce-" + ext1Name);
-          });
-      });
+      it(`HTTP Header contains 'ce-${ext1Name}'`, () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(response.config.headers)
+            .to.have.property(`ce-${ext1Name}`);
+        }));
 
-      it("HTTP Header contains 'ce-" + ext2Name + "'", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(response.config.headers)
-              .to.have.property("ce-" + ext2Name);
-          });
-      });
+      it(`HTTP Header contains 'ce-${ext2Name}'`, () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(response.config.headers)
+            .to.have.property(`ce-${ext2Name}`);
+        }));
 
-      it("HTTP Header contains 'ce-subject'", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(response.config.headers)
-              .to.have.property("ce-subject");
-          });
-      });
+      it("HTTP Header contains 'ce-subject'", () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(response.config.headers)
+            .to.have.property("ce-subject");
+        }));
 
-      it("should 'ce-type' have the right value", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(cloudevent.getType())
-              .to.equal(response.config.headers["ce-type"]);
-          });
-      });
+      it("should 'ce-type' have the right value", () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(cloudevent.getType())
+            .to.equal(response.config.headers["ce-type"]);
+        }));
 
-      it("should 'ce-specversion' have the right value", () => {
-        return binary.emit(cloudevent)
+      it("should 'ce-specversion' have the right value",
+        () => binary.emit(cloudevent)
           .then((response) => {
             expect(cloudevent.getSpecversion())
               .to.equal(response.config.headers["ce-specversion"]);
-          });
-      });
+          }));
 
-      it("should 'ce-source' have the right value", () => {
-        return binary.emit(cloudevent)
+      it("should 'ce-source' have the right value",
+        () => binary.emit(cloudevent)
           .then((response) => {
             expect(cloudevent.getSource())
               .to.equal(response.config.headers["ce-source"]);
-          });
-      });
+          }));
 
-      it("should 'ce-id' have the right value", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(cloudevent.getId())
-              .to.equal(response.config.headers["ce-id"]);
-          });
-      });
+      it("should 'ce-id' have the right value", () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(cloudevent.getId())
+            .to.equal(response.config.headers["ce-id"]);
+        }));
 
-      it("should 'ce-time' have the right value", () => {
-        return binary.emit(cloudevent)
-          .then((response) => {
-            expect(cloudevent.getTime())
-              .to.equal(response.config.headers["ce-time"]);
-          });
-      });
+      it("should 'ce-time' have the right value", () => binary.emit(cloudevent)
+        .then((response) => {
+          expect(cloudevent.getTime())
+            .to.equal(response.config.headers["ce-time"]);
+        }));
 
-      it("should 'ce-dataschema' have the right value", () => {
-        return binary.emit(cloudevent)
+      it("should 'ce-dataschema' have the right value",
+        () => binary.emit(cloudevent)
           .then((response) => {
             expect(cloudevent.getDataschema())
               .to.equal(response.config.headers["ce-dataschema"]);
-          });
-      });
+          }));
 
-      it("should 'ce-" + ext1Name + "' have the right value", () => {
-        return binary.emit(cloudevent)
+      it(`should 'ce-${ext1Name}' have the right value`,
+        () => binary.emit(cloudevent)
           .then((response) => {
             expect(cloudevent.getExtensions()[ext1Name])
-              .to.equal(response.config.headers["ce-" + ext1Name]);
-          });
-      });
+              .to.equal(response.config.headers[`ce-${ext1Name}`]);
+          }));
 
-      it("should 'ce-" + ext2Name + "' have the right value", () => {
-        return binary.emit(cloudevent)
+      it(`should 'ce-${ext2Name}' have the right value`,
+        () => binary.emit(cloudevent)
           .then((response) => {
             expect(cloudevent.getExtensions()[ext2Name])
-              .to.equal(response.config.headers["ce-" + ext2Name]);
-          });
-      });
+              .to.equal(response.config.headers[`ce-${ext2Name}`]);
+          }));
 
-      it("should 'ce-subject' have the right value", () => {
-        return binary.emit(cloudevent)
+      it("should 'ce-subject' have the right value",
+        () => binary.emit(cloudevent)
           .then((response) => {
             expect(cloudevent.getSubject())
               .to.equal(response.config.headers["ce-subject"]);
-          });
-      });
+          }));
     });
   });
 });

--- a/test/spec_0_3_tests.js
+++ b/test/spec_0_3_tests.js
@@ -1,19 +1,18 @@
 const expect = require("chai").expect;
 const Spec03 = require("../lib/specs/spec_0_3.js");
 const Cloudevent = require("../index.js");
-const uuid  = require("uuid/v4");
+const uuid = require("uuid/v4");
 
 const id = uuid();
-const type   = "com.github.pull.create";
+const type = "com.github.pull.create";
 const source = "urn:event:from:myapi/resourse/123";
-const time   = new Date();
+const time = new Date();
 const schemaurl = "http://example.com/registry/myschema.json";
 const dataContentEncoding = "base64";
 const dataContentType = "application/json";
 const data = {
-  much : "wow"
+  much: "wow"
 };
-const extensions = {};
 const subject = "subject-x0";
 
 var cloudevent =
@@ -28,7 +27,6 @@ var cloudevent =
     .data(data);
 
 describe("CloudEvents Spec v0.3", () => {
-
   describe("REQUIRED Attributes", () => {
     it("Should have 'id'", () => {
       expect(cloudevent.getId()).to.equal(id);
@@ -83,7 +81,7 @@ describe("CloudEvents Spec v0.3", () => {
 
     it("Should have the 'extension1'", () => {
       cloudevent.addExtension("extension1", "value1");
-      expect(cloudevent.spec.payload["extension1"])
+      expect(cloudevent.spec.payload.extension1)
         .to.equal("value1");
     });
 
@@ -96,11 +94,11 @@ describe("CloudEvents Spec v0.3", () => {
   describe("The Constraints check", () => {
     describe("'id'", () => {
       it("should throw an error when is absent", () => {
-          delete cloudevent.spec.payload.id;
-          expect(cloudevent.format.bind(cloudevent))
-            .to
-            .throw("invalid payload");
-          cloudevent.spec.payload.id = id;
+        delete cloudevent.spec.payload.id;
+        expect(cloudevent.format.bind(cloudevent))
+          .to
+          .throw("invalid payload");
+        cloudevent.spec.payload.id = id;
       });
 
       it("should throw an erro when is empty", () => {
@@ -114,21 +112,21 @@ describe("CloudEvents Spec v0.3", () => {
 
     describe("'source'", () => {
       it("should throw an error when is absent", () => {
-          delete cloudevent.spec.payload.source;
-          expect(cloudevent.format.bind(cloudevent))
-            .to
-            .throw("invalid payload");
-          cloudevent.spec.payload.source = source;
+        delete cloudevent.spec.payload.source;
+        expect(cloudevent.format.bind(cloudevent))
+          .to
+          .throw("invalid payload");
+        cloudevent.spec.payload.source = source;
       });
     });
 
     describe("'specversion'", () => {
       it("should throw an error when is absent", () => {
-          delete cloudevent.spec.payload.specversion;
-          expect(cloudevent.format.bind(cloudevent))
-            .to
-            .throw("invalid payload");
-          cloudevent.spec.payload.specversion = "0.3";
+        delete cloudevent.spec.payload.specversion;
+        expect(cloudevent.format.bind(cloudevent))
+          .to
+          .throw("invalid payload");
+        cloudevent.spec.payload.specversion = "0.3";
       });
 
       it("should throw an error when is empty", () => {
@@ -142,11 +140,11 @@ describe("CloudEvents Spec v0.3", () => {
 
     describe("'type'", () => {
       it("should throw an error when is absent", () => {
-          delete cloudevent.spec.payload.type;
-          expect(cloudevent.format.bind(cloudevent))
-            .to
-            .throw("invalid payload");
-          cloudevent.spec.payload.type = type;
+        delete cloudevent.spec.payload.type;
+        expect(cloudevent.format.bind(cloudevent))
+          .to
+          .throw("invalid payload");
+        cloudevent.spec.payload.type = type;
       });
 
       it("should throw an error when is an empty string", () => {
@@ -164,7 +162,7 @@ describe("CloudEvents Spec v0.3", () => {
     });
 
     describe("'datacontentencoding'", () => {
-      it("should throw an error when is a unsupported encoding" , () => {
+      it("should throw an error when is a unsupported encoding", () => {
         cloudevent
           .data("Y2xvdWRldmVudHMK")
           .dataContentEncoding("binary");
@@ -177,19 +175,18 @@ describe("CloudEvents Spec v0.3", () => {
 
       it("should throw an error when 'data' does not carry base64",
         () => {
+          cloudevent
+            .data("no base 64 value")
+            .dataContentEncoding("base64")
+            .dataContentType("text/plain");
 
-        cloudevent
-          .data("no base 64 value")
-          .dataContentEncoding("base64")
-          .dataContentType("text/plain");
+          expect(cloudevent.format.bind(cloudevent))
+            .to
+            .throw("invalid payload");
 
-        expect(cloudevent.format.bind(cloudevent))
-          .to
-          .throw("invalid payload");
-
-        delete cloudevent.spec.payload.datacontentencoding;
-        cloudevent.data(data);
-      });
+          delete cloudevent.spec.payload.datacontentencoding;
+          cloudevent.data(data);
+        });
 
       it("should accept when 'data' is a string", () => {
         cloudevent
@@ -202,12 +199,12 @@ describe("CloudEvents Spec v0.3", () => {
     });
 
     describe("'data'", () => {
-      it("should maintain the type of data when no data content type", () =>{
+      it("should maintain the type of data when no data content type", () => {
         delete cloudevent.spec.payload.datacontenttype;
         cloudevent
           .data(JSON.stringify(data));
 
-        expect(typeof cloudevent.getData()).to.equal("string");  
+        expect(typeof cloudevent.getData()).to.equal("string");
         cloudevent.dataContentType(dataContentType);
       });
 
@@ -232,9 +229,8 @@ describe("CloudEvents Spec v0.3", () => {
     describe("'time'", () => {
       it("must adhere to the format specified in RFC 3339", () => {
         cloudevent.time(time);
-        expect(cloudevent.format()["time"]).to.equal(time.toISOString());
+        expect(cloudevent.format().time).to.equal(time.toISOString());
       });
     });
   });
-
 });

--- a/test/spec_1_tests.js
+++ b/test/spec_1_tests.js
@@ -1,19 +1,18 @@
 const expect = require("chai").expect;
 const Spec1 = require("../lib/specs/spec_1.js");
 const Cloudevent = require("../index.js");
-const uuid  = require("uuid/v4");
-const {asBase64} = require("../lib/utils/fun.js");
+const uuid = require("uuid/v4");
+const { asBase64 } = require("../lib/utils/fun.js");
 
 const id = uuid();
-const type   = "com.github.pull.create";
+const type = "com.github.pull.create";
 const source = "urn:event:from:myapi/resourse/123";
-const time   = new Date();
+const time = new Date();
 const dataschema = "http://example.com/registry/myschema.json";
 const dataContentType = "application/json";
 const data = {
-  much : "wow"
+  much: "wow"
 };
-const extensions = {};
 const subject = "subject-x0";
 
 const cloudevent =
@@ -78,13 +77,13 @@ describe("CloudEvents Spec v1.0", () => {
     });
 
     it("should be ok when type is 'string'", () => {
-      cloudevent.addExtension("ext-string", 'an-string');
+      cloudevent.addExtension("ext-string", "an-string");
       expect(cloudevent.spec.payload["ext-string"])
         .to.equal("an-string");
     });
 
     it("should be ok when type is 'Uint32Array' for 'Binary'", () => {
-      let myBinary = new Uint32Array(2019);
+      const myBinary = new Uint32Array(2019);
       cloudevent.addExtension("ext-binary", myBinary);
       expect(cloudevent.spec.payload["ext-binary"])
         .to.equal(myBinary);
@@ -93,7 +92,7 @@ describe("CloudEvents Spec v1.0", () => {
     // URI
 
     it("should be ok when type is 'Date' for 'Timestamp'", () => {
-      let myDate = new Date();
+      const myDate = new Date();
       cloudevent.addExtension("ext-date", myDate);
       expect(cloudevent.spec.payload["ext-date"])
         .to.equal(myDate);
@@ -101,7 +100,7 @@ describe("CloudEvents Spec v1.0", () => {
 
     it("Should have the 'extension1'", () => {
       cloudevent.addExtension("extension1", "value1");
-      expect(cloudevent.spec.payload["extension1"])
+      expect(cloudevent.spec.payload.extension1)
         .to.equal("value1");
     });
 
@@ -111,7 +110,8 @@ describe("CloudEvents Spec v1.0", () => {
     });
 
     it("should throw an error when use an invalid type", () => {
-      expect(cloudevent.addExtension.bind(cloudevent, "invalid-val", {cool:'nice'}))
+      expect(cloudevent
+        .addExtension.bind(cloudevent, "invalid-val", { cool: "nice" }))
         .to.throw("Invalid type of extension value");
     });
   });
@@ -119,11 +119,11 @@ describe("CloudEvents Spec v1.0", () => {
   describe("The Constraints check", () => {
     describe("'id'", () => {
       it("should throw an error when is absent", () => {
-          delete cloudevent.spec.payload.id;
-          expect(cloudevent.format.bind(cloudevent))
-            .to
-            .throw("invalid payload");
-          cloudevent.spec.payload.id = id;
+        delete cloudevent.spec.payload.id;
+        expect(cloudevent.format.bind(cloudevent))
+          .to
+          .throw("invalid payload");
+        cloudevent.spec.payload.id = id;
       });
 
       it("should throw an erro when is empty", () => {
@@ -137,21 +137,21 @@ describe("CloudEvents Spec v1.0", () => {
 
     describe("'source'", () => {
       it("should throw an error when is absent", () => {
-          delete cloudevent.spec.payload.source;
-          expect(cloudevent.format.bind(cloudevent))
-            .to
-            .throw("invalid payload");
-          cloudevent.spec.payload.source = source;
+        delete cloudevent.spec.payload.source;
+        expect(cloudevent.format.bind(cloudevent))
+          .to
+          .throw("invalid payload");
+        cloudevent.spec.payload.source = source;
       });
     });
 
     describe("'specversion'", () => {
       it("should throw an error when is absent", () => {
-          delete cloudevent.spec.payload.specversion;
-          expect(cloudevent.format.bind(cloudevent))
-            .to
-            .throw("invalid payload");
-          cloudevent.spec.payload.specversion = "1.0";
+        delete cloudevent.spec.payload.specversion;
+        expect(cloudevent.format.bind(cloudevent))
+          .to
+          .throw("invalid payload");
+        cloudevent.spec.payload.specversion = "1.0";
       });
 
       it("should throw an error when is empty", () => {
@@ -165,11 +165,11 @@ describe("CloudEvents Spec v1.0", () => {
 
     describe("'type'", () => {
       it("should throw an error when is absent", () => {
-          delete cloudevent.spec.payload.type;
-          expect(cloudevent.format.bind(cloudevent))
-            .to
-            .throw("invalid payload");
-          cloudevent.spec.payload.type = type;
+        delete cloudevent.spec.payload.type;
+        expect(cloudevent.format.bind(cloudevent))
+          .to
+          .throw("invalid payload");
+        cloudevent.spec.payload.type = type;
       });
 
       it("should throw an error when is an empty string", () => {
@@ -199,7 +199,7 @@ describe("CloudEvents Spec v1.0", () => {
     describe("'time'", () => {
       it("must adhere to the format specified in RFC 3339", () => {
         cloudevent.time(time);
-        expect(cloudevent.format()["time"]).to.equal(time.toISOString());
+        expect(cloudevent.format().time).to.equal(time.toISOString());
       });
     });
   });
@@ -209,7 +209,7 @@ describe("CloudEvents Spec v1.0", () => {
       expect(cloudevent.getData()).to.deep.equal(data);
     });
 
-    it("should maintain the type of data when no data content type", () =>{
+    it("should maintain the type of data when no data content type", () => {
       delete cloudevent.spec.payload.datacontenttype;
       cloudevent
         .data(JSON.stringify(data));
@@ -226,11 +226,11 @@ describe("CloudEvents Spec v1.0", () => {
     });
 
     it("should be ok when type is 'Uint32Array' for 'Binary'", () => {
-      let dataString = ")(*~^my data for ce#@#$%"
+      const dataString = ")(*~^my data for ce#@#$%";
 
-      let dataBinary = Uint32Array.from(dataString, (c) => c.codePointAt(0));
-      let expected = asBase64(dataBinary);
-      let olddct  = cloudevent.getDataContentType();
+      const dataBinary = Uint32Array.from(dataString, (c) => c.codePointAt(0));
+      const expected = asBase64(dataBinary);
+      const olddct = cloudevent.getDataContentType();
 
       cloudevent
         .dataContentType("text/plain")

--- a/v02/index.js
+++ b/v02/index.js
@@ -2,7 +2,7 @@ const Cloudevent = require("../lib/cloudevent.js");
 const Spec = require("../lib/specs/spec_0_2.js");
 const StructuredHTTPEmitter =
   require("../lib/bindings/http/emitter_structured_0_2.js");
-const {HTTPBinary02} = require("../lib/bindings/http/emitter_binary_0_2.js");
+const { HTTPBinary02 } = require("../lib/bindings/http/emitter_binary_0_2.js");
 const StructuredHTTPReceiver =
   require("../lib/bindings/http/receiver_structured_0_2.js");
 const BinaryHTTPReceiver =
@@ -18,7 +18,7 @@ module.exports = {
   Spec,
   StructuredHTTPEmitter,
   StructuredHTTPReceiver,
-  BinaryHTTPEmitter : HTTPBinary02,
+  BinaryHTTPEmitter: HTTPBinary02,
   BinaryHTTPReceiver,
   HTTPUnmarshaller,
   event


### PR DESCRIPTION
The linting configuration is based on [`eslint-recommended`](https://eslint.org/docs/user-guide/configuring#using-eslint-recommended) with some customization for arrow functions, double quoted strings and a few other things.

Running `npx standardx --fix` automatically fixed > 2000 issues. The remaining 200+ issues need
to be fixed by hand. Additionally, all strings are double quotes which is not typically standard and I wonder about fixing that too.

This is a potentially large change since it touches most files, marking as WIP.

Fixes: https://github.com/cloudevents/sdk-javascript/issues/54

Signed-off-by: Lance Ball <lball@redhat.com>