### PR TITLE
fix: Fix Express example installation

### DIFF
--- a/examples/express-ex/package.json
+++ b/examples/express-ex/package.json
@@ -14,7 +14,7 @@
   "author": "fabiojose@gmail.com",
   "license": "Apache-2.0",
   "dependencies": {
-    "cloudevents-sdk": "github:cloudevents/sdk-javascript#v1",
+    "cloudevents-sdk": "~1.0.0",
     "express": "^4.17.1"
   }
 }


### PR DESCRIPTION
Related to #76 

Now it uses the same approach as TypeScript example: https://github.com/cloudevents/sdk-javascript/blob/master/examples/typescript-ex/package.json#L28