### PR TITLE
chore: fix CI code coverage publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "mocha test/**/*.js",
     "coverage": "nyc --reporter=lcov --reporter=text npm run test",
     "precoverage-publish": "npm run coverage",
-    "coverage-publish": "wget -qO - https://coverage.codacy.com/get.sh | sh -s report -l JavaScript -r coverage/lcov.info",
+    "coverage-publish": "wget -qO - https://coverage.codacy.com/get.sh | bash -s report -l JavaScript -r coverage/lcov.info",
     "release": "standard-version"
   },
   "standard-version": {


### PR DESCRIPTION
The code coverage publishing in package.json works fine on non-ubuntu systems.
However, in Ubuntu `/bin/sh` is symlinked to `/bin/dash` which doesn't support
everything supported by `/bin/bash` - specifically `-o pipefail`.

This commit changes the code coverage script to explicitly use `bash` instead.

Signed-off-by: Lance Ball <lball@redhat.com>