### PR TITLE
refactor: use CloudEvents not cloudevents everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Checkout the new expressive additions.
 > There is full example: [typescript-ex](./examples/typescript-ex)
 
 ```ts
-import Cloudevent, {
+import CloudEvent, {
   event,
   StructuredHTTPEmitter,
   BinaryHTTPEmitter,
@@ -51,7 +51,7 @@ import Cloudevent, {
   BinaryHTTPReceiver
 } from 'cloudevents-sdk/v1';
 
-let myevent: Cloudevent = event()
+let myevent: CloudEvent = event()
   .source('/source')
   .type('type')
   .dataContentType('text/plain')
@@ -231,7 +231,7 @@ app.post("/", (req, res) => {
 - `ext`: external stuff, e.g, Cloud Events JSONSchema
 - `lib/bindings`: every binding implementation goes here
 - `lib/bindings/http`: every http binding implementation goes here
-- `lib/cloudevent.js`: implementation of Cloudevent, an interface
+- `lib/cloudevent.js`: implementation of CloudEvent, an interface
 - `lib/formats/`: every format implementation goes here
 - `lib/specs/`: every spec implementation goes here
 
@@ -245,18 +245,18 @@ npm test
 
 ## The API
 
-### `Cloudevent` class
+### `CloudEvent` class
 
 ```js
 /*
  * Format the payload and return an Object.
  */
-Object Cloudevent.format()
+Object CloudEvent.format()
 
 /*
  * Format the payload as String.
  */
-String Cloudevent.toString()
+String CloudEvent.toString()
 ```
 
 ### `Formatter` classes
@@ -265,12 +265,12 @@ Every formatter class must implement these methods to work properly.
 
 ```js
 /*
- * Format the Cloudevent payload argument and return an Object.
+ * Format the CloudEvent payload argument and return an Object.
  */
 Object Formatter.format(Object)
 
 /*
- * Format the Cloudevent payload as String.
+ * Format the CloudEvent payload as String.
  */
 String Formatter.toString(Object)
 ```
@@ -297,9 +297,9 @@ Every Spec class must implement these methods to work properly.
 
 ```js
 /*
- * The constructor must receives the Cloudevent type.
+ * The constructor must receives the CloudEvent type.
  */
-Spec(Cloudevent)
+Spec(CloudEvent)
 
 /*
  * Checks the spec constraints, throwing an error if do not pass.
@@ -320,7 +320,7 @@ Every Binding class must implement these methods to work properly.
 
 #### Emitter Binding
 
-Following we have the signature for the binding to emit Cloudevents.
+Following we have the signature for the binding to emit CloudEvents.
 
 ```js
 /*
@@ -329,14 +329,14 @@ Following we have the signature for the binding to emit Cloudevents.
 Binding(config)
 
 /*
- * Emits the event using an instance of Cloudevent.
+ * Emits the event using an instance of CloudEvent.
  */
-Binding.emit(cloudevent)
+Binding.emit(cloudEvent)
 ```
 
 #### Receiver Binding
 
-Following we have the signature for the binding to receive Cloudevents.
+Following we have the signature for the binding to receive CloudEvents.
 
 ```js
 /*
@@ -351,9 +351,9 @@ Receiver(config)
 Receiver.check(Object, Map)
 
 /*
- * Checks and parse as Cloudevent
+ * Checks and parse as CloudEvent
  */
-Cloudevent Receiver.parse(Object, Map)
+CloudEvent Receiver.parse(Object, Map)
 ```
 
 > See how to implement the method injection [here](lib/specs/spec_0_1.js#L17)

--- a/examples/typescript-ex/src/index.ts
+++ b/examples/typescript-ex/src/index.ts
@@ -1,4 +1,4 @@
-import Cloudevent, {
+import CloudEvent, {
   event,
   StructuredHTTPEmitter,
   BinaryHTTPEmitter,
@@ -8,7 +8,7 @@ import Cloudevent, {
 
 export function doSomeStuff() {
 
-  const myevent: Cloudevent = event()
+  const myevent: CloudEvent = event()
     .source('/source')
     .type('type')
     .dataContentType('text/plain')

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-var Cloudevent = require("./lib/cloudevent.js");
+var CloudEvent = require("./lib/cloudevent.js");
 
-module.exports = Cloudevent;
+module.exports = CloudEvent;

--- a/lib/bindings/http/receiver_binary.js
+++ b/lib/bindings/http/receiver_binary.js
@@ -1,6 +1,6 @@
 const Constants = require("./constants.js");
 const Commons = require("./commons.js");
-const Cloudevent = require("../../cloudevent.js");
+const CloudEvent = require("../../cloudevent.js");
 
 const {
   isDefinedOrThrow,
@@ -88,7 +88,7 @@ BinaryHTTPReceiver.prototype.parse = function(payload, headers) {
   const sanityHeaders = Commons.sanityAndClone(headers);
 
   const processedHeaders = [];
-  const cloudevent = new Cloudevent(this.Spec);
+  const cloudevent = new CloudEvent(this.Spec);
 
   // dont worry, check() have seen what was required or not
   Array.from(Object.keys(this.setterByHeader))

--- a/lib/bindings/http/receiver_structured.js
+++ b/lib/bindings/http/receiver_structured.js
@@ -1,6 +1,6 @@
 const Constants = require("./constants.js");
 const Commons = require("./commons.js");
-const Cloudevent = require("../../cloudevent.js");
+const CloudEvent = require("../../cloudevent.js");
 
 const {
   isDefinedOrThrow,
@@ -61,7 +61,7 @@ StructuredHTTPReceiver.prototype.parse = function(payload, headers) {
   this.spec.check(event);
 
   const processedAttributes = [];
-  const cloudevent = new Cloudevent(this.Spec);
+  const cloudevent = new CloudEvent(this.Spec);
 
   Array.from(Object.keys(this.setterByAttribute))
     .filter((attribute) => event[attribute])

--- a/test/bindings/http/receiver_binary_0_3_tests.js
+++ b/test/bindings/http/receiver_binary_0_3_tests.js
@@ -147,7 +147,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
   });
 
   describe("Parse", () => {
-    it("Cloudevent contains 'type'", () => {
+    it("CloudEvent contains 'type'", () => {
       // setup
       var payload = {
         data: "dataString"
@@ -170,7 +170,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
         .to.equal("type");
     });
 
-    it("Cloudevent contains 'specversion'", () => {
+    it("CloudEvent contains 'specversion'", () => {
       // setup
       var payload = {
         data: "dataString"
@@ -193,7 +193,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
         .to.equal("0.3");
     });
 
-    it("Cloudevent contains 'source'", () => {
+    it("CloudEvent contains 'source'", () => {
       // setup
       var payload = {
         data: "dataString"
@@ -216,7 +216,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
         .to.equal("/source");
     });
 
-    it("Cloudevent contains 'id'", () => {
+    it("CloudEvent contains 'id'", () => {
       // setup
       var payload = {
         data: "dataString"
@@ -239,7 +239,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
         .to.equal("id");
     });
 
-    it("Cloudevent contains 'time'", () => {
+    it("CloudEvent contains 'time'", () => {
       // setup
       var payload = {
         data: "dataString"
@@ -262,7 +262,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
         .to.equal("2019-06-16T11:42:00.000Z");
     });
 
-    it("Cloudevent contains 'schemaurl'", () => {
+    it("CloudEvent contains 'schemaurl'", () => {
       // setup
       var payload = {
         data: "dataString"
@@ -285,7 +285,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
         .to.equal("http://schema.registry/v1");
     });
 
-    it("Cloudevent contains 'datacontenttype' (application/json)", () => {
+    it("CloudEvent contains 'datacontenttype' (application/json)", () => {
       // setup
       var payload = {
         data: "dataString"
@@ -308,7 +308,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
         .to.equal("application/json");
     });
 
-    it("Cloudevent contains 'datacontenttype' (application/octet-stream)",
+    it("CloudEvent contains 'datacontenttype' (application/octet-stream)",
       () => {
       // setup
         var payload = "The payload is binary data";
@@ -330,7 +330,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
           .to.equal("application/octet-stream");
       });
 
-    it("Cloudevent contains 'data' (application/json)", () => {
+    it("CloudEvent contains 'data' (application/json)", () => {
       // setup
       var payload = {
         data: "dataString"
@@ -353,7 +353,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
         .to.deep.equal(payload);
     });
 
-    it("Cloudevent contains 'data' (application/octet-stream)", () => {
+    it("CloudEvent contains 'data' (application/octet-stream)", () => {
       // setup
       var payload = "The payload is binary data";
       var attributes = {

--- a/test/bindings/http/receiver_binary_1_tests.js
+++ b/test/bindings/http/receiver_binary_1_tests.js
@@ -148,7 +148,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
   });
 
   describe("Parse", () => {
-    it("Cloudevent contains 'type'", () => {
+    it("CloudEvent contains 'type'", () => {
       // setup
       var payload = {
         data: "dataString"
@@ -171,7 +171,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
         .to.equal("type");
     });
 
-    it("Cloudevent contains 'specversion'", () => {
+    it("CloudEvent contains 'specversion'", () => {
       // setup
       var payload = {
         data: "dataString"
@@ -194,7 +194,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
         .to.equal("1.0");
     });
 
-    it("Cloudevent contains 'source'", () => {
+    it("CloudEvent contains 'source'", () => {
       // setup
       var payload = {
         data: "dataString"
@@ -217,7 +217,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
         .to.equal("/source");
     });
 
-    it("Cloudevent contains 'id'", () => {
+    it("CloudEvent contains 'id'", () => {
       // setup
       var payload = {
         data: "dataString"
@@ -240,7 +240,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
         .to.equal("id");
     });
 
-    it("Cloudevent contains 'time'", () => {
+    it("CloudEvent contains 'time'", () => {
       // setup
       var payload = {
         data: "dataString"
@@ -263,7 +263,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
         .to.equal("2019-06-16T11:42:00.000Z");
     });
 
-    it("Cloudevent contains 'dataschema'", () => {
+    it("CloudEvent contains 'dataschema'", () => {
       // setup
       var payload = {
         data: "dataString"
@@ -286,7 +286,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
         .to.equal("http://schema.registry/v1");
     });
 
-    it("Cloudevent contains 'contenttype' (application/json)", () => {
+    it("CloudEvent contains 'contenttype' (application/json)", () => {
       // setup
       var payload = {
         data: "dataString"
@@ -309,7 +309,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
         .to.equal("application/json");
     });
 
-    it("Cloudevent contains 'contenttype' (application/octet-stream)", () => {
+    it("CloudEvent contains 'contenttype' (application/octet-stream)", () => {
       // setup
       var payload = "The payload is binary data";
       var attributes = {
@@ -330,7 +330,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
         .to.equal("application/octet-stream");
     });
 
-    it("Cloudevent contains 'data' (application/json)", () => {
+    it("CloudEvent contains 'data' (application/json)", () => {
       // setup
       var payload = {
         data: "dataString"
@@ -353,7 +353,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
         .to.deep.equal(payload);
     });
 
-    it("Cloudevent contains 'data' (application/octet-stream)", () => {
+    it("CloudEvent contains 'data' (application/octet-stream)", () => {
       // setup
       var payload = "The payload is binary data";
       var attributes = {

--- a/test/bindings/http/receiver_structured_1_test.js
+++ b/test/bindings/http/receiver_structured_1_test.js
@@ -1,6 +1,6 @@
 var expect = require("chai").expect;
 var v1 = require("../../../v1/index.js");
-var Cloudevent = require("../../../index.js");
+var CloudEvent = require("../../../index.js");
 
 const { asBase64 } = require("../../../lib/utils/fun.js");
 
@@ -82,7 +82,7 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v1.0",
       it("Throw error when the event does not follow the spec", () => {
       // setup
         var payload =
-        new Cloudevent()
+        new CloudEvent()
           .type(type)
           .source(source)
           .time(now)

--- a/test/bindings/http/unmarshaller_0_3_tests.js
+++ b/test/bindings/http/unmarshaller_0_3_tests.js
@@ -1,6 +1,6 @@
 var expect = require("chai").expect;
 var Unmarshaller = require("../../../lib/bindings/http/unmarshaller_0_3.js");
-var Cloudevent = require("../../../index.js");
+var CloudEvent = require("../../../index.js");
 var v03 = require("../../../v03/index.js");
 
 const type = "com.github.pull.create";
@@ -117,7 +117,7 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
     it("Should accept event that follow the spec 0.3", () => {
       // setup
       var payload =
-        new Cloudevent(v03.Spec)
+        new CloudEvent(v03.Spec)
           .type(type)
           .source(source)
           .dataContentType(ceContentType)
@@ -146,7 +146,7 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
     it("Should parse 'data' stringfied json to json object", () => {
       // setup
       var payload =
-        new Cloudevent(v03.Spec)
+        new CloudEvent(v03.Spec)
           .type(type)
           .source(source)
           .dataContentType(ceContentType)

--- a/test/http_binding_0_3.js
+++ b/test/http_binding_0_3.js
@@ -2,7 +2,7 @@ const expect = require("chai").expect;
 const nock = require("nock");
 const BinaryHTTPEmitter =
   require("../lib/bindings/http/emitter_binary_0_3.js");
-const Cloudevent = require("../lib/cloudevent.js");
+const CloudEvent = require("../lib/cloudevent.js");
 const v03 = require("../v03/index.js");
 
 const type = "com.github.pull.create";
@@ -25,7 +25,7 @@ const ext2Name = "extension2";
 const ext2Value = "acme";
 
 const cloudevent =
-  new Cloudevent(v03.Spec)
+  new CloudEvent(v03.Spec)
     .type(type)
     .source(source)
     .dataContentType(ceContentType)
@@ -37,7 +37,7 @@ const cloudevent =
     .addExtension(ext2Name, ext2Value);
 
 const cebase64 =
-  new Cloudevent(v03.Spec)
+  new CloudEvent(v03.Spec)
     .type(type)
     .source(source)
     .dataContentType(ceContentType)

--- a/test/http_binding_1.js
+++ b/test/http_binding_1.js
@@ -7,7 +7,7 @@ const {
   Spec,
   BinaryHTTPEmitter,
   StructuredHTTPEmitter,
-  Cloudevent
+  CloudEvent
 } = require("../v1/index.js");
 
 const type = "com.github.pull.create";
@@ -28,7 +28,7 @@ const ext2Name = "extension2";
 const ext2Value = "acme";
 
 const cloudevent =
-  new Cloudevent(Spec)
+  new CloudEvent(Spec)
     .type(type)
     .source(source)
     .dataContentType(ceContentType)
@@ -94,7 +94,7 @@ describe("HTTP Transport Binding - Version 1.0", () => {
           const bindata = Uint32Array.from(dataString, (c) => c.codePointAt(0));
           const expected = asBase64(bindata);
           const binevent =
-            new Cloudevent(Spec)
+            new CloudEvent(Spec)
               .type(type)
               .source(source)
               .dataContentType("text/plain")
@@ -111,7 +111,7 @@ describe("HTTP Transport Binding - Version 1.0", () => {
 
         it("the payload must have 'data_base64' when data is binary", () => {
           const binevent =
-            new Cloudevent(Spec)
+            new CloudEvent(Spec)
               .type(type)
               .source(source)
               .dataContentType("text/plain")
@@ -164,7 +164,7 @@ describe("HTTP Transport Binding - Version 1.0", () => {
           const bindata = Uint32Array.from(dataString, (c) => c.codePointAt(0));
           const expected = asBase64(bindata);
           const binevent =
-          new Cloudevent(Spec)
+          new CloudEvent(Spec)
             .type(type)
             .source(source)
             .dataContentType("text/plain")

--- a/test/spec_0_3_tests.js
+++ b/test/spec_0_3_tests.js
@@ -1,6 +1,6 @@
 const expect = require("chai").expect;
 const Spec03 = require("../lib/specs/spec_0_3.js");
-const Cloudevent = require("../index.js");
+const CloudEvent = require("../index.js");
 const uuid = require("uuid/v4");
 
 const id = uuid();
@@ -16,7 +16,7 @@ const data = {
 const subject = "subject-x0";
 
 var cloudevent =
-  new Cloudevent(Spec03)
+  new CloudEvent(Spec03)
     .id(id)
     .source(source)
     .type(type)

--- a/test/spec_1_tests.js
+++ b/test/spec_1_tests.js
@@ -1,6 +1,6 @@
 const expect = require("chai").expect;
 const Spec1 = require("../lib/specs/spec_1.js");
-const Cloudevent = require("../index.js");
+const CloudEvent = require("../index.js");
 const uuid = require("uuid/v4");
 const { asBase64 } = require("../lib/utils/fun.js");
 
@@ -16,7 +16,7 @@ const data = {
 const subject = "subject-x0";
 
 const cloudevent =
-  new Cloudevent(Spec1)
+  new CloudEvent(Spec1)
     .id(id)
     .source(source)
     .type(type)

--- a/v03/index.js
+++ b/v03/index.js
@@ -1,4 +1,4 @@
-const Cloudevent = require("../lib/cloudevent.js");
+const CloudEvent = require("../lib/cloudevent.js");
 const Spec = require("../lib/specs/spec_0_3.js");
 const StructuredHTTPEmitter =
   require("../lib/bindings/http/emitter_structured.js");
@@ -12,8 +12,8 @@ const BinaryHTTPReceiver =
 
 const HTTPUnmarshaller = require("../lib/bindings/http/unmarshaller_0_3.js");
 
-function event() {
-  return new Cloudevent(Spec);
+function newEvent() {
+  return new CloudEvent(Spec);
 }
 
 module.exports = {
@@ -23,7 +23,6 @@ module.exports = {
   BinaryHTTPEmitter,
   BinaryHTTPReceiver,
   HTTPUnmarshaller,
-  Cloudevent,
-  CloudEvent: Cloudevent,
-  event
+  CloudEvent: newEvent,
+  event: newEvent
 };

--- a/v1/index.js
+++ b/v1/index.js
@@ -1,4 +1,4 @@
-const Cloudevent = require("../lib/cloudevent.js");
+const CloudEvent = require("../lib/cloudevent.js");
 const Spec = require("../lib/specs/spec_1.js");
 
 const StructuredHTTPEmitter =
@@ -12,8 +12,8 @@ const StructuredHTTPReceiver =
 const BinaryHTTPReceiver =
   require("../lib/bindings/http/receiver_binary_1.js");
 
-function event() {
-  return new Cloudevent(Spec);
+function newEvent() {
+  return new CloudEvent(Spec);
 }
 
 module.exports = {
@@ -22,7 +22,6 @@ module.exports = {
   BinaryHTTPEmitter,
   StructuredHTTPReceiver,
   BinaryHTTPReceiver,
-  Cloudevent: event,
-  CloudEvent: event,
-  event
+  CloudEvent: newEvent,
+  event: newEvent
 };


### PR DESCRIPTION
Uses the same capitalization for CloudEvents everywhere.
Fixes #100.