### PR TITLE
chore: update eslint rules to disallow var usage

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,7 @@
     "mocha": true
   },
   "rules": {
+    "no-var": "error",
     "space-before-function-paren": ["error", "never"],
     "standard/no-callback-literal": "off",
     "arrow-spacing": "error",

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-var Cloudevent = require("./lib/cloudevent.js");
+const Cloudevent = require("./lib/cloudevent.js");
 
 module.exports = Cloudevent;

--- a/lib/formats/json/parser.js
+++ b/lib/formats/json/parser.js
@@ -19,7 +19,7 @@ const asJSON = (v) => (isString(v) ? JSON.parse(v) : v);
 
 // Level 0 of validation: is that string? is that JSON?
 function validateAndParse(payload) {
-  var json =
+  const json =
     Array.of(payload)
       .filter((p) => isDefinedOrThrow(p, nullOrIndefinedPayload))
       .filter((p) => isStringOrObjectOrThrow(p, invalidPayloadTypeError))

--- a/lib/specs/spec_1.js
+++ b/lib/specs/spec_1.js
@@ -109,7 +109,7 @@ function Spec1(_caller) {
  * Check the spec constraints
  */
 Spec1.prototype.check = function(ce) {
-  var toCheck = (!ce ? this.payload : ce);
+  const toCheck = (!ce ? this.payload : ce);
 
   if (!isValidAgainstSchema(toCheck)) {
     const err = new TypeError("invalid payload");

--- a/test/bindings/http/receiver_binary_0_3_tests.js
+++ b/test/bindings/http/receiver_binary_0_3_tests.js
@@ -1,16 +1,16 @@
-var expect = require("chai").expect;
+const expect = require("chai").expect;
 
-var HTTPBinaryReceiver =
+const HTTPBinaryReceiver =
   require("../../../lib/bindings/http/receiver_binary_0_3.js");
 
-var receiver = new HTTPBinaryReceiver();
+const receiver = new HTTPBinaryReceiver();
 
 describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
   describe("Check", () => {
     it("Throw error when payload arg is null or undefined", () => {
       // setup
-      var payload = null;
-      var attributes = {};
+      const payload = null;
+      const attributes = {};
 
       // act and assert
       expect(receiver.check.bind(receiver, payload, attributes))
@@ -19,8 +19,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
 
     it("Throw error when attributes arg is null or undefined", () => {
       // setup
-      var payload = {};
-      var attributes = null;
+      const payload = {};
+      const attributes = null;
 
       // act and assert
       expect(receiver.check.bind(receiver, payload, attributes))
@@ -29,8 +29,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
 
     it("Throw error when payload is not an object or string", () => {
       // setup
-      var payload = 1.2;
-      var attributes = {};
+      const payload = 1.2;
+      const attributes = {};
 
       // act and assert
       expect(receiver.check.bind(receiver, payload, attributes))
@@ -39,8 +39,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
 
     it("Throw error when headers has no 'ce-type'", () => {
       // setup
-      var payload = {};
-      var attributes = {
+      const payload = {};
+      const attributes = {
         "ce-specversion": "specversion",
         "ce-source": "source",
         "ce-id": "id",
@@ -54,8 +54,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
 
     it("Throw error when headers has no 'ce-specversion'", () => {
       // setup
-      var payload = {};
-      var attributes = {
+      const payload = {};
+      const attributes = {
         "ce-type": "type",
         "ce-source": "source",
         "ce-id": "id",
@@ -69,8 +69,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
 
     it("Throw error when headers has no 'ce-source'", () => {
       // setup
-      var payload = {};
-      var attributes = {
+      const payload = {};
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "specversion",
         "ce-id": "id",
@@ -84,8 +84,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
 
     it("Throw error when headers has no 'ce-id'", () => {
       // setup
-      var payload = {};
-      var attributes = {
+      const payload = {};
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "specversion",
         "ce-source": "source",
@@ -99,8 +99,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
 
     it("Throw error when spec is not 0.3", () => {
       // setup
-      var payload = {};
-      var attributes = {
+      const payload = {};
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "0.2",
         "ce-source": "source",
@@ -115,8 +115,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
 
     it("Throw error when the content-type is invalid", () => {
       // setup
-      var payload = {};
-      var attributes = {
+      const payload = {};
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "specversion",
         "ce-source": "source",
@@ -131,8 +131,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
 
     it("No error when all required headers are in place", () => {
       // setup
-      var payload = {};
-      var attributes = {
+      const payload = {};
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "0.3",
         "ce-source": "source",
@@ -149,10 +149,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
   describe("Parse", () => {
     it("Cloudevent contains 'type'", () => {
       // setup
-      var payload = {
+      const payload = {
         data: "dataString"
       };
-      var attributes = {
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "0.3",
         "ce-source": "source",
@@ -163,7 +163,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
       };
 
       // act
-      var actual = receiver.parse(payload, attributes);
+      const actual = receiver.parse(payload, attributes);
 
       // assert
       expect(actual.getType())
@@ -172,10 +172,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
 
     it("Cloudevent contains 'specversion'", () => {
       // setup
-      var payload = {
+      const payload = {
         data: "dataString"
       };
-      var attributes = {
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "0.3",
         "ce-source": "source",
@@ -186,7 +186,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
       };
 
       // act
-      var actual = receiver.parse(payload, attributes);
+      const actual = receiver.parse(payload, attributes);
 
       // assert
       expect(actual.getSpecversion())
@@ -195,10 +195,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
 
     it("Cloudevent contains 'source'", () => {
       // setup
-      var payload = {
+      const payload = {
         data: "dataString"
       };
-      var attributes = {
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "0.3",
         "ce-source": "/source",
@@ -209,7 +209,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
       };
 
       // act
-      var actual = receiver.parse(payload, attributes);
+      const actual = receiver.parse(payload, attributes);
 
       // assert
       expect(actual.getSource())
@@ -218,10 +218,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
 
     it("Cloudevent contains 'id'", () => {
       // setup
-      var payload = {
+      const payload = {
         data: "dataString"
       };
-      var attributes = {
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "0.3",
         "ce-source": "/source",
@@ -232,7 +232,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
       };
 
       // act
-      var actual = receiver.parse(payload, attributes);
+      const actual = receiver.parse(payload, attributes);
 
       // assert
       expect(actual.getId())
@@ -241,10 +241,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
 
     it("Cloudevent contains 'time'", () => {
       // setup
-      var payload = {
+      const payload = {
         data: "dataString"
       };
-      var attributes = {
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "0.3",
         "ce-source": "/source",
@@ -255,7 +255,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
       };
 
       // act
-      var actual = receiver.parse(payload, attributes);
+      const actual = receiver.parse(payload, attributes);
 
       // assert
       expect(actual.getTime())
@@ -264,10 +264,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
 
     it("Cloudevent contains 'schemaurl'", () => {
       // setup
-      var payload = {
+      const payload = {
         data: "dataString"
       };
-      var attributes = {
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "0.3",
         "ce-source": "/source",
@@ -278,7 +278,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
       };
 
       // act
-      var actual = receiver.parse(payload, attributes);
+      const actual = receiver.parse(payload, attributes);
 
       // assert
       expect(actual.getSchemaurl())
@@ -287,10 +287,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
 
     it("Cloudevent contains 'datacontenttype' (application/json)", () => {
       // setup
-      var payload = {
+      const payload = {
         data: "dataString"
       };
-      var attributes = {
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "0.3",
         "ce-source": "/source",
@@ -301,7 +301,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
       };
 
       // act
-      var actual = receiver.parse(payload, attributes);
+      const actual = receiver.parse(payload, attributes);
 
       // assert
       expect(actual.getDataContentType())
@@ -311,8 +311,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
     it("Cloudevent contains 'datacontenttype' (application/octet-stream)",
       () => {
       // setup
-        var payload = "The payload is binary data";
-        var attributes = {
+        const payload = "The payload is binary data";
+        const attributes = {
           "ce-type": "type",
           "ce-specversion": "0.3",
           "ce-source": "/source",
@@ -323,7 +323,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
         };
 
         // act
-        var actual = receiver.parse(payload, attributes);
+        const actual = receiver.parse(payload, attributes);
 
         // assert
         expect(actual.getDataContentType())
@@ -332,10 +332,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
 
     it("Cloudevent contains 'data' (application/json)", () => {
       // setup
-      var payload = {
+      const payload = {
         data: "dataString"
       };
-      var attributes = {
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "0.3",
         "ce-source": "/source",
@@ -346,7 +346,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
       };
 
       // act
-      var actual = receiver.parse(payload, attributes);
+      const actual = receiver.parse(payload, attributes);
 
       // assert
       expect(actual.getData())
@@ -355,8 +355,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
 
     it("Cloudevent contains 'data' (application/octet-stream)", () => {
       // setup
-      var payload = "The payload is binary data";
-      var attributes = {
+      const payload = "The payload is binary data";
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "0.3",
         "ce-source": "/source",
@@ -367,7 +367,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
       };
 
       // act
-      var actual = receiver.parse(payload, attributes);
+      const actual = receiver.parse(payload, attributes);
 
       // assert
       expect(actual.getData())
@@ -376,10 +376,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
 
     it("No error when all attributes are in place", () => {
       // setup
-      var payload = {
+      const payload = {
         data: "dataString"
       };
-      var attributes = {
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "0.3",
         "ce-source": "source",
@@ -390,7 +390,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
       };
 
       // act
-      var actual = receiver.parse(payload, attributes);
+      const actual = receiver.parse(payload, attributes);
 
       // assert
       expect(actual)
@@ -402,11 +402,11 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
 
     it("Should accept 'extension1'", () => {
       // setup
-      var extension1 = "mycuston-ext1";
-      var payload = {
+      const extension1 = "mycuston-ext1";
+      const payload = {
         data: "dataString"
       };
-      var attributes = {
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "0.3",
         "ce-source": "source",
@@ -418,8 +418,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
       };
 
       // act
-      var actual = receiver.parse(payload, attributes);
-      var actualExtensions = actual.getExtensions();
+      const actual = receiver.parse(payload, attributes);
+      const actualExtensions = actual.getExtensions();
 
       // assert
       expect(actualExtensions.extension1)

--- a/test/bindings/http/receiver_binary_1_tests.js
+++ b/test/bindings/http/receiver_binary_1_tests.js
@@ -10,8 +10,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
   describe("Check", () => {
     it("Throw error when payload arg is null or undefined", () => {
       // setup
-      var payload = null;
-      var attributes = {};
+      const payload = null;
+      const attributes = {};
 
       // act and assert
       expect(receiver.check.bind(receiver, payload, attributes))
@@ -20,8 +20,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
 
     it("Throw error when attributes arg is null or undefined", () => {
       // setup
-      var payload = {};
-      var attributes = null;
+      const payload = {};
+      const attributes = null;
 
       // act and assert
       expect(receiver.check.bind(receiver, payload, attributes))
@@ -30,8 +30,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
 
     it("Throw error when payload is not an object or string", () => {
       // setup
-      var payload = 1.2;
-      var attributes = {};
+      const payload = 1.2;
+      const attributes = {};
 
       // act and assert
       expect(receiver.check.bind(receiver, payload, attributes))
@@ -40,8 +40,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
 
     it("Throw error when headers has no 'ce-type'", () => {
       // setup
-      var payload = {};
-      var attributes = {
+      const payload = {};
+      const attributes = {
         "ce-specversion": "specversion",
         "ce-source": "source",
         "ce-id": "id",
@@ -55,8 +55,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
 
     it("Throw error when headers has no 'ce-specversion'", () => {
       // setup
-      var payload = {};
-      var attributes = {
+      const payload = {};
+      const attributes = {
         "ce-type": "type",
         "ce-source": "source",
         "ce-id": "id",
@@ -70,8 +70,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
 
     it("Throw error when headers has no 'ce-source'", () => {
       // setup
-      var payload = {};
-      var attributes = {
+      const payload = {};
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "specversion",
         "ce-id": "id",
@@ -85,8 +85,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
 
     it("Throw error when headers has no 'ce-id'", () => {
       // setup
-      var payload = {};
-      var attributes = {
+      const payload = {};
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "specversion",
         "ce-source": "source",
@@ -100,8 +100,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
 
     it("Throw error when spec is not 1.0", () => {
       // setup
-      var payload = {};
-      var attributes = {
+      const payload = {};
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "0.2",
         "ce-source": "source",
@@ -116,8 +116,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
 
     it("Throw error when the content-type is invalid", () => {
       // setup
-      var payload = {};
-      var attributes = {
+      const payload = {};
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "specversion",
         "ce-source": "source",
@@ -132,8 +132,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
 
     it("No error when all required headers are in place", () => {
       // setup
-      var payload = {};
-      var attributes = {
+      const payload = {};
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "1.0",
         "ce-source": "source",
@@ -150,10 +150,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
   describe("Parse", () => {
     it("Cloudevent contains 'type'", () => {
       // setup
-      var payload = {
+      const payload = {
         data: "dataString"
       };
-      var attributes = {
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "1.0",
         "ce-source": "source",
@@ -164,7 +164,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
       };
 
       // act
-      var actual = receiver.parse(payload, attributes);
+      const actual = receiver.parse(payload, attributes);
 
       // assert
       expect(actual.getType())
@@ -173,10 +173,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
 
     it("Cloudevent contains 'specversion'", () => {
       // setup
-      var payload = {
+      const payload = {
         data: "dataString"
       };
-      var attributes = {
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "1.0",
         "ce-source": "source",
@@ -187,7 +187,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
       };
 
       // act
-      var actual = receiver.parse(payload, attributes);
+      const actual = receiver.parse(payload, attributes);
 
       // assert
       expect(actual.getSpecversion())
@@ -196,10 +196,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
 
     it("Cloudevent contains 'source'", () => {
       // setup
-      var payload = {
+      const payload = {
         data: "dataString"
       };
-      var attributes = {
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "1.0",
         "ce-source": "/source",
@@ -210,7 +210,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
       };
 
       // act
-      var actual = receiver.parse(payload, attributes);
+      const actual = receiver.parse(payload, attributes);
 
       // assert
       expect(actual.getSource())
@@ -219,10 +219,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
 
     it("Cloudevent contains 'id'", () => {
       // setup
-      var payload = {
+      const payload = {
         data: "dataString"
       };
-      var attributes = {
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "1.0",
         "ce-source": "/source",
@@ -233,7 +233,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
       };
 
       // act
-      var actual = receiver.parse(payload, attributes);
+      const actual = receiver.parse(payload, attributes);
 
       // assert
       expect(actual.getId())
@@ -242,10 +242,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
 
     it("Cloudevent contains 'time'", () => {
       // setup
-      var payload = {
+      const payload = {
         data: "dataString"
       };
-      var attributes = {
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "1.0",
         "ce-source": "/source",
@@ -256,7 +256,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
       };
 
       // act
-      var actual = receiver.parse(payload, attributes);
+      const actual = receiver.parse(payload, attributes);
 
       // assert
       expect(actual.getTime())
@@ -265,10 +265,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
 
     it("Cloudevent contains 'dataschema'", () => {
       // setup
-      var payload = {
+      const payload = {
         data: "dataString"
       };
-      var attributes = {
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "1.0",
         "ce-source": "/source",
@@ -279,7 +279,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
       };
 
       // act
-      var actual = receiver.parse(payload, attributes);
+      const actual = receiver.parse(payload, attributes);
 
       // assert
       expect(actual.getDataschema())
@@ -288,10 +288,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
 
     it("Cloudevent contains 'contenttype' (application/json)", () => {
       // setup
-      var payload = {
+      const payload = {
         data: "dataString"
       };
-      var attributes = {
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "1.0",
         "ce-source": "/source",
@@ -302,7 +302,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
       };
 
       // act
-      var actual = receiver.parse(payload, attributes);
+      const actual = receiver.parse(payload, attributes);
 
       // assert
       expect(actual.getDataContentType())
@@ -311,8 +311,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
 
     it("Cloudevent contains 'contenttype' (application/octet-stream)", () => {
       // setup
-      var payload = "The payload is binary data";
-      var attributes = {
+      const payload = "The payload is binary data";
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "1.0",
         "ce-source": "/source",
@@ -323,7 +323,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
       };
 
       // act
-      var actual = receiver.parse(payload, attributes);
+      const actual = receiver.parse(payload, attributes);
 
       // assert
       expect(actual.getDataContentType())
@@ -332,10 +332,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
 
     it("Cloudevent contains 'data' (application/json)", () => {
       // setup
-      var payload = {
+      const payload = {
         data: "dataString"
       };
-      var attributes = {
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "1.0",
         "ce-source": "/source",
@@ -346,7 +346,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
       };
 
       // act
-      var actual = receiver.parse(payload, attributes);
+      const actual = receiver.parse(payload, attributes);
 
       // assert
       expect(actual.getData())
@@ -355,8 +355,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
 
     it("Cloudevent contains 'data' (application/octet-stream)", () => {
       // setup
-      var payload = "The payload is binary data";
-      var attributes = {
+      const payload = "The payload is binary data";
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "1.0",
         "ce-source": "/source",
@@ -367,7 +367,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
       };
 
       // act
-      var actual = receiver.parse(payload, attributes);
+      const actual = receiver.parse(payload, attributes);
 
       // assert
       expect(actual.getData())
@@ -376,7 +376,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
 
     it("The content of 'data' is base64 for binary", () => {
       // setup
-      var expected = {
+      const expected = {
         data: "dataString"
       };
 
@@ -384,7 +384,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
         .from(JSON.stringify(expected), (c) => c.codePointAt(0));
       const payload = asBase64(bindata);
 
-      var attributes = {
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "1.0",
         "ce-source": "/source",
@@ -395,7 +395,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
       };
 
       // act
-      var actual = receiver.parse(payload, attributes);
+      const actual = receiver.parse(payload, attributes);
 
       // assert
       expect(actual.getData())
@@ -404,10 +404,10 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
 
     it("No error when all attributes are in place", () => {
       // setup
-      var payload = {
+      const payload = {
         data: "dataString"
       };
-      var attributes = {
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "1.0",
         "ce-source": "source",
@@ -418,7 +418,7 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
       };
 
       // act
-      var actual = receiver.parse(payload, attributes);
+      const actual = receiver.parse(payload, attributes);
 
       // assert
       expect(actual)
@@ -430,11 +430,11 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
 
     it("Should accept 'extension1'", () => {
       // setup
-      var extension1 = "mycuston-ext1";
-      var payload = {
+      const extension1 = "mycuston-ext1";
+      const payload = {
         data: "dataString"
       };
-      var attributes = {
+      const attributes = {
         "ce-type": "type",
         "ce-specversion": "1.0",
         "ce-source": "source",
@@ -446,8 +446,8 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
       };
 
       // act
-      var actual = receiver.parse(payload, attributes);
-      var actualExtensions = actual.getExtensions();
+      const actual = receiver.parse(payload, attributes);
+      const actualExtensions = actual.getExtensions();
 
       // assert
       expect(actualExtensions.extension1)

--- a/test/bindings/http/receiver_structured_0_3_test.js
+++ b/test/bindings/http/receiver_structured_0_3_test.js
@@ -1,10 +1,10 @@
-var expect = require("chai").expect;
-var v03 = require("../../../v03/index.js");
+const expect = require("chai").expect;
+const v03 = require("../../../v03/index.js");
 
-var HTTPStructuredReceiver =
+const HTTPStructuredReceiver =
   require("../../../lib/bindings/http/receiver_structured_0_3.js");
 
-var receiver = new HTTPStructuredReceiver();
+const receiver = new HTTPStructuredReceiver();
 
 const type = "com.github.pull.create";
 const source = "urn:event:from:myapi/resourse/123";
@@ -26,8 +26,8 @@ describe("HTTP Transport Binding Structured Receiver CloudEvents v0.3", () => {
   describe("Check", () => {
     it("Throw error when payload arg is null or undefined", () => {
       // setup
-      var payload = null;
-      var attributes = {};
+      const payload = null;
+      const attributes = {};
 
       // act and assert
       expect(receiver.check.bind(receiver, payload, attributes))
@@ -36,8 +36,8 @@ describe("HTTP Transport Binding Structured Receiver CloudEvents v0.3", () => {
 
     it("Throw error when attributes arg is null or undefined", () => {
       // setup
-      var payload = {};
-      var attributes = null;
+      const payload = {};
+      const attributes = null;
 
       // act and assert
       expect(receiver.check.bind(receiver, payload, attributes))
@@ -46,8 +46,8 @@ describe("HTTP Transport Binding Structured Receiver CloudEvents v0.3", () => {
 
     it("Throw error when payload is not an object or string", () => {
       // setup
-      var payload = 1.0;
-      var attributes = {};
+      const payload = 1.0;
+      const attributes = {};
 
       // act and assert
       expect(receiver.check.bind(receiver, payload, attributes))
@@ -56,8 +56,8 @@ describe("HTTP Transport Binding Structured Receiver CloudEvents v0.3", () => {
 
     it("Throw error when the content-type is invalid", () => {
       // setup
-      var payload = {};
-      var attributes = {
+      const payload = {};
+      const attributes = {
         "Content-Type": "text/html"
       };
 
@@ -92,8 +92,8 @@ describe("HTTP Transport Binding Structured Receiver CloudEvents v0.3", () => {
 
     it("No error when all required stuff are in place", () => {
       // setup
-      var payload = {};
-      var attributes = {
+      const payload = {};
+      const attributes = {
         "Content-Type": "application/cloudevents+json"
       };
 
@@ -106,8 +106,8 @@ describe("HTTP Transport Binding Structured Receiver CloudEvents v0.3", () => {
   describe("Parse", () => {
     it("Throw error when the event does not follow the spec", () => {
       // setup
-      var payload = {};
-      var attributes = {
+      const payload = {};
+      const attributes = {
         "Content-Type": "application/cloudevents+json"
       };
 
@@ -120,7 +120,7 @@ describe("HTTP Transport Binding Structured Receiver CloudEvents v0.3", () => {
   describe("Parse", () => {
     it("Throw error when the event does not follow the spec", () => {
       // setup
-      var payload =
+      const payload =
         v03.event()
           .type(type)
           .source(source)
@@ -129,7 +129,7 @@ describe("HTTP Transport Binding Structured Receiver CloudEvents v0.3", () => {
           .data(data)
           .toString();
 
-      var headers = {
+      const headers = {
         "Content-Type": "application/cloudevents+xml"
       };
 
@@ -140,8 +140,8 @@ describe("HTTP Transport Binding Structured Receiver CloudEvents v0.3", () => {
 
     it("Should accept event that follows the spec", () => {
       // setup
-      var id = "id-x0dk";
-      var payload = v03.event()
+      const id = "id-x0dk";
+      const payload = v03.event()
         .type(type)
         .source(source)
         .id(id)
@@ -150,12 +150,12 @@ describe("HTTP Transport Binding Structured Receiver CloudEvents v0.3", () => {
         .schemaurl(schemaurl)
         .data(data)
         .toString();
-      var headers = {
+      const headers = {
         "content-type": "application/cloudevents+json"
       };
 
       // act
-      var actual = receiver.parse(payload, headers);
+      const actual = receiver.parse(payload, headers);
 
       // assert
       expect(actual)
@@ -170,8 +170,8 @@ describe("HTTP Transport Binding Structured Receiver CloudEvents v0.3", () => {
 
     it("Should accept 'extension1'", () => {
       // setup
-      var extension1 = "mycuston-ext1";
-      var payload = v03.event()
+      const extension1 = "mycuston-ext1";
+      const payload = v03.event()
         .type(type)
         .source(source)
         .dataContentType(ceContentType)
@@ -181,13 +181,13 @@ describe("HTTP Transport Binding Structured Receiver CloudEvents v0.3", () => {
         .addExtension("extension1", extension1)
         .toString();
 
-      var headers = {
+      const headers = {
         "content-type": "application/cloudevents+json"
       };
 
       // act
-      var actual = receiver.parse(payload, headers);
-      var actualExtensions = actual.getExtensions();
+      const actual = receiver.parse(payload, headers);
+      const actualExtensions = actual.getExtensions();
 
       // assert
       expect(actualExtensions.extension1)
@@ -196,7 +196,7 @@ describe("HTTP Transport Binding Structured Receiver CloudEvents v0.3", () => {
 
     it("Should parse 'data' stringfied json to json object", () => {
       // setup
-      var payload = v03.event()
+      const payload = v03.event()
         .type(type)
         .source(source)
         .dataContentType(ceContentType)
@@ -205,12 +205,12 @@ describe("HTTP Transport Binding Structured Receiver CloudEvents v0.3", () => {
         .data(JSON.stringify(data))
         .toString();
 
-      var headers = {
+      const headers = {
         "content-type": "application/cloudevents+json"
       };
 
       // act
-      var actual = receiver.parse(payload, headers);
+      const actual = receiver.parse(payload, headers);
 
       // assert
       expect(actual.getData()).to.deep.equal(data);

--- a/test/bindings/http/receiver_structured_1_test.js
+++ b/test/bindings/http/receiver_structured_1_test.js
@@ -1,13 +1,13 @@
-var expect = require("chai").expect;
-var v1 = require("../../../v1/index.js");
-var Cloudevent = require("../../../index.js");
+const expect = require("chai").expect;
+const v1 = require("../../../v1/index.js");
+const Cloudevent = require("../../../index.js");
 
 const { asBase64 } = require("../../../lib/utils/fun.js");
 
-var HTTPStructuredReceiver =
+const HTTPStructuredReceiver =
   require("../../../lib/bindings/http/receiver_structured_1.js");
 
-var receiver = new HTTPStructuredReceiver();
+const receiver = new HTTPStructuredReceiver();
 
 const type = "com.github.pull.create";
 const source = "urn:event:from:myapi/resourse/123";
@@ -25,8 +25,8 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v1.0",
     describe("Check", () => {
       it("Throw error when payload arg is null or undefined", () => {
       // setup
-        var payload = null;
-        var attributes = {};
+        const payload = null;
+        const attributes = {};
 
         // act and assert
         expect(receiver.check.bind(receiver, payload, attributes))
@@ -35,8 +35,8 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v1.0",
 
       it("Throw error when attributes arg is null or undefined", () => {
       // setup
-        var payload = {};
-        var attributes = null;
+        const payload = {};
+        const attributes = null;
 
         // act and assert
         expect(receiver.check.bind(receiver, payload, attributes))
@@ -45,8 +45,8 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v1.0",
 
       it("Throw error when payload is not an object or string", () => {
       // setup
-        var payload = 1.0;
-        var attributes = {};
+        const payload = 1.0;
+        const attributes = {};
 
         // act and assert
         expect(receiver.check.bind(receiver, payload, attributes))
@@ -55,8 +55,8 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v1.0",
 
       it("Throw error when the content-type is invalid", () => {
       // setup
-        var payload = {};
-        var attributes = {
+        const payload = {};
+        const attributes = {
           "Content-Type": "text/html"
         };
 
@@ -67,8 +67,8 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v1.0",
 
       it("No error when all required stuff are in place", () => {
       // setup
-        var payload = {};
-        var attributes = {
+        const payload = {};
+        const attributes = {
           "Content-Type": "application/cloudevents+json"
         };
 
@@ -81,7 +81,7 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v1.0",
     describe("Parse", () => {
       it("Throw error when the event does not follow the spec", () => {
       // setup
-        var payload =
+        const payload =
         new Cloudevent()
           .type(type)
           .source(source)
@@ -89,7 +89,7 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v1.0",
           .data(data)
           .toString();
 
-        var headers = {
+        const headers = {
           "Content-Type": "application/cloudevents+xml"
         };
 
@@ -100,8 +100,8 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v1.0",
 
       it("Should accept event that follows the spec", () => {
       // setup
-        var id = "id-x0dk";
-        var payload = v1.event()
+        const id = "id-x0dk";
+        const payload = v1.event()
           .type(type)
           .source(source)
           .id(id)
@@ -110,12 +110,12 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v1.0",
           .dataschema(dataschema)
           .data(data)
           .toString();
-        var headers = {
+        const headers = {
           "content-type": "application/cloudevents+json"
         };
 
         // act
-        var actual = receiver.parse(payload, headers);
+        const actual = receiver.parse(payload, headers);
 
         // assert
         expect(actual)
@@ -130,8 +130,8 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v1.0",
 
       it("Should accept 'extension1'", () => {
       // setup
-        var extension1 = "mycuston-ext1";
-        var payload = v1.event()
+        const extension1 = "mycuston-ext1";
+        const payload = v1.event()
           .type(type)
           .source(source)
           .dataContentType(ceContentType)
@@ -141,13 +141,13 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v1.0",
           .addExtension("extension1", extension1)
           .toString();
 
-        var headers = {
+        const headers = {
           "content-type": "application/cloudevents+json"
         };
 
         // act
-        var actual = receiver.parse(payload, headers);
-        var actualExtensions = actual.getExtensions();
+        const actual = receiver.parse(payload, headers);
+        const actualExtensions = actual.getExtensions();
 
         // assert
         expect(actualExtensions.extension1)
@@ -156,7 +156,7 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v1.0",
 
       it("Should parse 'data' stringfied json to json object", () => {
       // setup
-        var payload = v1.event()
+        const payload = v1.event()
           .type(type)
           .source(source)
           .dataContentType(ceContentType)
@@ -165,12 +165,12 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v1.0",
           .data(JSON.stringify(data))
           .toString();
 
-        var headers = {
+        const headers = {
           "content-type": "application/cloudevents+json"
         };
 
         // act
-        var actual = receiver.parse(payload, headers);
+        const actual = receiver.parse(payload, headers);
 
         // assert
         expect(actual.getData()).to.deep.equal(data);
@@ -188,12 +188,12 @@ describe("HTTP Transport Binding Structured Receiver for CloudEvents v1.0",
           .data(bindata)
           .format();
 
-        var headers = {
+        const headers = {
           "content-type": "application/cloudevents+json"
         };
 
         // act
-        var actual = receiver.parse(JSON.stringify(payload), headers);
+        const actual = receiver.parse(JSON.stringify(payload), headers);
 
         // assert
         expect(actual.getData()).to.equal(expected);

--- a/test/bindings/http/unmarshaller_0_3_tests.js
+++ b/test/bindings/http/unmarshaller_0_3_tests.js
@@ -1,7 +1,7 @@
-var expect = require("chai").expect;
-var Unmarshaller = require("../../../lib/bindings/http/unmarshaller_0_3.js");
-var Cloudevent = require("../../../index.js");
-var v03 = require("../../../v03/index.js");
+const expect = require("chai").expect;
+const Unmarshaller = require("../../../lib/bindings/http/unmarshaller_0_3.js");
+const Cloudevent = require("../../../index.js");
+const v03 = require("../../../v03/index.js");
 
 const type = "com.github.pull.create";
 const source = "urn:event:from:myapi/resourse/123";
@@ -22,8 +22,8 @@ const data = {
 describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
   it("Throw error when payload is null", () => {
     // setup
-    var payload = null;
-    var un = new Unmarshaller();
+    const payload = null;
+    const un = new Unmarshaller();
 
     // act and assert
     return un.unmarshall(payload)
@@ -34,9 +34,9 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
 
   it("Throw error when headers is null", () => {
     // setup
-    var payload = {};
-    var headers = null;
-    var un = new Unmarshaller();
+    const payload = {};
+    const headers = null;
+    const un = new Unmarshaller();
 
     // act and assert
     return un.unmarshall(payload, headers)
@@ -47,9 +47,9 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
 
   it("Throw error when there is no content-type header", () => {
     // setup
-    var payload = {};
-    var headers = {};
-    var un = new Unmarshaller();
+    const payload = {};
+    const headers = {};
+    const un = new Unmarshaller();
 
     // act and assert
     un.unmarshall(payload, headers)
@@ -60,11 +60,11 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
 
   it("Throw error when content-type is not allowed", () => {
     // setup
-    var payload = {};
-    var headers = {
+    const payload = {};
+    const headers = {
       "content-type": "text/xml"
     };
-    var un = new Unmarshaller();
+    const un = new Unmarshaller();
 
     // act and assert
     un.unmarshall(payload, headers)
@@ -76,11 +76,11 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
   describe("Structured", () => {
     it("Throw error when has not allowed mime", () => {
       // setup
-      var payload = {};
-      var headers = {
+      const payload = {};
+      const headers = {
         "content-type": "application/cloudevents+zip"
       };
-      var un = new Unmarshaller();
+      const un = new Unmarshaller();
 
       // act and assert
       un.unmarshall(payload, headers)
@@ -91,7 +91,7 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
 
     it("Throw error when the event does not follow the spec 0.3", () => {
       // setup
-      var payload =
+      const payload =
         new v03.CloudEvent(v03.Spec)
           .type(type)
           .source(source)
@@ -101,11 +101,11 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
           .data(data)
           .toString();
 
-      var headers = {
+      const headers = {
         "content-type": "application/cloudevents+json"
       };
 
-      var un = new Unmarshaller();
+      const un = new Unmarshaller();
 
       // act and assert
       un.unmarshall(payload, headers)
@@ -116,7 +116,7 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
 
     it("Should accept event that follow the spec 0.3", () => {
       // setup
-      var payload =
+      const payload =
         new Cloudevent(v03.Spec)
           .type(type)
           .source(source)
@@ -127,11 +127,11 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
           .data(data)
           .toString();
 
-      var headers = {
+      const headers = {
         "content-type": "application/cloudevents+json"
       };
 
-      var un = new Unmarshaller();
+      const un = new Unmarshaller();
 
       // act and assert
       return un.unmarshall(payload, headers)
@@ -145,7 +145,7 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
 
     it("Should parse 'data' stringfied json to json object", () => {
       // setup
-      var payload =
+      const payload =
         new Cloudevent(v03.Spec)
           .type(type)
           .source(source)
@@ -156,11 +156,11 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
           .data(JSON.stringify(data))
           .toString();
 
-      var headers = {
+      const headers = {
         "content-type": "application/cloudevents+json"
       };
 
-      var un = new Unmarshaller();
+      const un = new Unmarshaller();
 
       // act and assert
       return un.unmarshall(payload, headers)
@@ -177,10 +177,10 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
   describe("Binary", () => {
     it("Throw error when has not allowed mime", () => {
       // setup
-      var payload = {
+      const payload = {
         data: "dataString"
       };
-      var attributes = {
+      const attributes = {
         [BINARY_HEADERS_03.TYPE]: "type",
         [BINARY_HEADERS_03.SPEC_VERSION]: "0.3",
         [BINARY_HEADERS_03.SOURCE]: "source",
@@ -190,7 +190,7 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
         [HEADER_CONTENT_TYPE]: "text/html"
       };
 
-      var un = new Unmarshaller();
+      const un = new Unmarshaller();
 
       // act and assert
       un.unmarshall(payload, attributes)
@@ -201,10 +201,10 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
 
     it("Throw error when the event does not follow the spec 0.3", () => {
       // setup
-      var payload = {
+      const payload = {
         data: "dataString"
       };
-      var attributes = {
+      const attributes = {
         [BINARY_HEADERS_03.TYPE]: "type",
         "CE-CloudEventsVersion": "0.1",
         [BINARY_HEADERS_03.SOURCE]: "source",
@@ -214,7 +214,7 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
         [HEADER_CONTENT_TYPE]: "application/json"
       };
 
-      var un = new Unmarshaller();
+      const un = new Unmarshaller();
 
       // act and assert
       un.unmarshall(payload, attributes)
@@ -225,10 +225,10 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
 
     it("No error when all attributes are in place", () => {
       // setup
-      var payload = {
+      const payload = {
         data: "dataString"
       };
-      var attributes = {
+      const attributes = {
         [BINARY_HEADERS_03.TYPE]: "type",
         [BINARY_HEADERS_03.SPEC_VERSION]: "0.3",
         [BINARY_HEADERS_03.SOURCE]: "source",
@@ -238,7 +238,7 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
         [HEADER_CONTENT_TYPE]: "application/json"
       };
 
-      var un = new Unmarshaller();
+      const un = new Unmarshaller();
 
       // act and assert
       un.unmarshall(payload, attributes)
@@ -247,9 +247,9 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
 
     it("Throw error when 'ce-datacontentencoding' is not allowed", () => {
       // setup
-      var payload = "eyJtdWNoIjoid293In0=";
+      const payload = "eyJtdWNoIjoid293In0=";
 
-      var attributes = {
+      const attributes = {
         [BINARY_HEADERS_03.TYPE]: "type",
         [BINARY_HEADERS_03.SPEC_VERSION]: "0.3",
         [BINARY_HEADERS_03.SOURCE]: "source",
@@ -260,7 +260,7 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
         [BINARY_HEADERS_03.CONTENT_ENCONDING]: "binary"
       };
 
-      var un = new Unmarshaller();
+      const un = new Unmarshaller();
 
       // act and assert
       return un.unmarshall(payload, attributes)
@@ -272,12 +272,12 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
 
     it("No error when 'ce-datacontentencoding' is base64", () => {
       // setup
-      var payload = "eyJtdWNoIjoid293In0=";
+      const payload = "eyJtdWNoIjoid293In0=";
       const expected = {
         much: "wow"
       };
 
-      var attributes = {
+      const attributes = {
         [BINARY_HEADERS_03.TYPE]: "type",
         [BINARY_HEADERS_03.SPEC_VERSION]: "0.3",
         [BINARY_HEADERS_03.SOURCE]: "source",
@@ -288,7 +288,7 @@ describe("HTTP Transport Binding Unmarshaller for CloudEvents v0.3", () => {
         [BINARY_HEADERS_03.CONTENT_ENCONDING]: "base64"
       };
 
-      var un = new Unmarshaller();
+      const un = new Unmarshaller();
 
       // act and assert
       return un.unmarshall(payload, attributes)

--- a/test/formats/json/parser_test.js
+++ b/test/formats/json/parser_test.js
@@ -1,11 +1,11 @@
-var expect = require("chai").expect;
-var Parser = require("../../../lib/formats/json/parser.js");
+const expect = require("chai").expect;
+const Parser = require("../../../lib/formats/json/parser.js");
 
 describe("JSON Event Format Parser", () => {
   it("Throw error when payload is an integer", () => {
     // setup
-    var payload = 83;
-    var parser = new Parser();
+    const payload = 83;
+    const parser = new Parser();
 
     // act and assert
     expect(parser.parse.bind(parser, payload))
@@ -14,8 +14,8 @@ describe("JSON Event Format Parser", () => {
 
   it("Throw error when payload is null", () => {
     // setup
-    var payload = null;
-    var parser = new Parser();
+    const payload = null;
+    const parser = new Parser();
 
     // act and assert
     expect(parser.parse.bind(parser, payload))
@@ -24,7 +24,7 @@ describe("JSON Event Format Parser", () => {
 
   it("Throw error when payload is undefined", () => {
     // setup
-    var parser = new Parser();
+    const parser = new Parser();
 
     // act and assert
     expect(parser.parse.bind(parser))
@@ -33,8 +33,8 @@ describe("JSON Event Format Parser", () => {
 
   it("Throw error when payload is a float", () => {
     // setup
-    var payload = 8.3;
-    var parser = new Parser();
+    const payload = 8.3;
+    const parser = new Parser();
 
     // act and assert
     expect(parser.parse.bind(parser, payload))
@@ -43,8 +43,8 @@ describe("JSON Event Format Parser", () => {
 
   it("Throw error when payload is an invalid JSON", () => {
     // setup
-    var payload = "gg";
-    var parser = new Parser();
+    const payload = "gg";
+    const parser = new Parser();
 
     // act and assert
     expect(parser.parse.bind(parser, payload))
@@ -53,11 +53,11 @@ describe("JSON Event Format Parser", () => {
 
   it("Must accept when the payload is a string well formed as JSON", () => {
     // setup
-    var payload = "{\"much\" : \"wow\"}";
-    var parser = new Parser();
+    const payload = "{\"much\" : \"wow\"}";
+    const parser = new Parser();
 
     // act
-    var actual = parser.parse(payload);
+    const actual = parser.parse(payload);
 
     // assert
     expect(actual)

--- a/test/spec_0_3_tests.js
+++ b/test/spec_0_3_tests.js
@@ -15,7 +15,7 @@ const data = {
 };
 const subject = "subject-x0";
 
-var cloudevent =
+const cloudevent =
   new Cloudevent(Spec03)
     .id(id)
     .source(source)


### PR DESCRIPTION
Enforce the use of `let` and `const` by using elsint rules.
When creating the eslint configuration, I had assumed that
`extends: eslint:recommended` would have covered this, but
apparently not!

Existing usage of `var` fixed with `npm run lint -- --fix`.

Fixes: https://github.com/cloudevents/sdk-javascript/issues/97

Signed-off-by: Lance Ball <lball@redhat.com>