### PR TITLE
fix: [backport] support mTLS in 1.0 Binary and Structured emitters

### DIFF
--- a/lib/bindings/http/emitter_binary.js
+++ b/lib/bindings/http/emitter_binary.js
@@ -2,58 +2,48 @@ var axios = require("axios");
 var empty = require("is-empty");
 
 const Constants = require("./constants.js");
+const defaults = {};
+defaults[Constants.HEADERS] = {};
+defaults[Constants.HEADERS][Constants.HEADER_CONTENT_TYPE] = Constants.DEFAULT_CONTENT_TYPE;
 
 function BinaryHTTPEmitter(config, headerByGetter, extensionPrefix){
-  this.config = JSON.parse(JSON.stringify(config));
+  this.config = Object.assign({}, defaults, config);
   this.headerByGetter = headerByGetter;
   this.extensionPrefix = extensionPrefix;
-
-  this.config[Constants.HEADERS] =
-    (!this.config[Constants.HEADERS]
-      ? {}
-      : this.config[Constants.HEADERS]);
-
-  // default is json
-  if(!this.config[Constants.HEADERS][Constants.HEADER_CONTENT_TYPE]){
-    this.config[Constants.HEADERS][Constants.HEADER_CONTENT_TYPE] =
-      Constants.DEFAULT_CONTENT_TYPE;
-  }
 }
 
-BinaryHTTPEmitter.prototype.emit = function(cloudevent) {
-  // Create new request object
-  var _config = JSON.parse(JSON.stringify(this.config));
-
-  // Always set stuff in _config
-  var _headers = _config[Constants.HEADERS];
+BinaryHTTPEmitter.prototype.emit = function (cloudevent) {
+  const config = Object.assign({}, this.config);
+  const headers = Object.assign({}, this.config[Constants.HEADERS]);
 
   Object.keys(this.headerByGetter)
     .filter((getter) => cloudevent[getter]())
     .forEach((getter) => {
-      let header = this.headerByGetter[getter];
-      _headers[header.name] =
+      const header = this.headerByGetter[getter];
+      headers[header.name] =
         header.parser(
           cloudevent[getter]()
         );
     });
 
   // Set the cloudevent payload
-  let formatted = cloudevent.format();
+  const formatted = cloudevent.format();
   let data = formatted.data;
   data = (formatted.data_base64 ? formatted.data_base64: data);
 
-  _config[Constants.DATA_ATTRIBUTE] = data;
-
   // Have extensions?
-  var exts = cloudevent.getExtensions();
+  const exts = cloudevent.getExtensions();
   Object.keys(exts)
     .filter((ext) => Object.hasOwnProperty.call(exts, ext))
     .forEach((ext) => {
-      _headers[this.extensionPrefix + ext] = exts[ext];
+      headers[this.extensionPrefix + ext] = exts[ext];
     });
 
-  // Return the Promise
-  return axios.request(_config);
-};
+  config[Constants.DATA_ATTRIBUTE] = data;
+  config.headers = headers;
+
+    // Return the Promise
+  return axios.request(config);
+ };
 
 module.exports = BinaryHTTPEmitter;

--- a/lib/bindings/http/emitter_structured.js
+++ b/lib/bindings/http/emitter_structured.js
@@ -1,30 +1,23 @@
 var axios = require("axios");
 
 const Constants = require("./constants.js");
+const defaults = {};
+defaults[Constants.HEADERS] = {};
+defaults[Constants.HEADERS][Constants.HEADER_CONTENT_TYPE] = Constants.DEFAULT_CE_CONTENT_TYPE;
 
 function StructuredHTTPEmitter(configuration){
-  this.config = JSON.parse(JSON.stringify(configuration));
-
-  this.config[Constants.HEADERS] =
-    (!this.config[Constants.HEADERS]
-      ? {}
-      : this.config[Constants.HEADERS]);
-
-  if(!this.config[Constants.HEADERS][Constants.HEADER_CONTENT_TYPE]){
-    this.config[Constants.HEADERS][Constants.HEADER_CONTENT_TYPE] =
-      Constants.DEFAULT_CE_CONTENT_TYPE;
-  }
+  this.config = Object.assign({}, defaults, configuration);
 }
 
-StructuredHTTPEmitter.prototype.emit = function(cloudevent) {
-  // Create new request object
-  var _config = JSON.parse(JSON.stringify(this.config));
-
+StructuredHTTPEmitter.prototype.emit = function (cloudevent) {
   // Set the cloudevent payload
-  _config[Constants.DATA_ATTRIBUTE] = cloudevent.format();
+  this.config[Constants.DATA_ATTRIBUTE] = cloudevent.format();
 
   // Return the Promise
-  return axios.request(_config);
+  return axios.request(this.config).then(response => {
+    delete this.config[Constants.DATA_ATTRIBUTE];
+    return response;
+  });
 };
 
 module.exports = StructuredHTTPEmitter;

--- a/v1/index.js
+++ b/v1/index.js
@@ -22,5 +22,7 @@ module.exports = {
   BinaryHTTPEmitter,
   StructuredHTTPReceiver,
   BinaryHTTPReceiver,
+  Cloudevent: event,
+  CloudEvent: event,
   event
 };


### PR DESCRIPTION
This commit modifies both of the 1.0 emitters so that they may
accept typed objects as a part of the configuration. When using
mTLS in Node, you need to provide an `Agent` to the underlying
HTTP handler. In this case, Axios will pass this object along to
Node.js when it is provided.

Landed in: https://github.com/cloudevents/sdk-javascript/commit/3a063d72451d1156df8fe9c3499ef1e81e905060
Pull Request: https://github.com/cloudevents/sdk-javascript/pull/53

Fixes: https://github.com/cloudevents/sdk-javascript/issues/48

Signed-off-by: Lance Ball <lball@redhat.com>