### PR TITLE
chore: remove note with bad link and non SDK docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,12 +356,6 @@ Receiver.check(Object, Map)
 CloudEvent Receiver.parse(Object, Map)
 ```
 
-> See how to implement the method injection [here](lib/specs/spec_0_1.js#L17)
->
-> Learn about [Builder Design Pattern](https://en.wikipedia.org/wiki/Builder_pattern)
->
-> Check out the produced event payload using this [tool](https://webhook.site)
-
 ## Community
 
 - There are bi-weekly calls immediately following the [Serverless/CloudEvents


### PR DESCRIPTION
There's a link to 0.1 and some other links in the README that aren't specific to the Node SDK. Let's remove them.