### PR TITLE
lib: use specversion from schema

### DIFF
--- a/lib/specs/spec_0_3.js
+++ b/lib/specs/spec_0_3.js
@@ -35,7 +35,7 @@ const isValidAgainstSchema = ajv.compile(schema);
 
 function Spec03(_caller) {
   this.payload = {
-    specversion: "0.3",
+    specversion: schema.definitions.specversion.const,
     id: uuidv4()
   };
 

--- a/lib/specs/spec_1.js
+++ b/lib/specs/spec_1.js
@@ -37,7 +37,7 @@ const isValidAgainstSchema = ajv.compile(schema);
 
 function Spec1(_caller) {
   this.payload = {
-    specversion: "1.0",
+    specversion: schema.definitions.specversion.const,
     id: uuidv4()
   };
 


### PR DESCRIPTION
This commit updates the 0.1 and 0.3 sources to use the specversion
available in schema definitions.

Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>