### PR TITLE
fix: make application/json the default content type in binary mode

### DIFF
--- a/lib/bindings/http/receiver_binary.js
+++ b/lib/bindings/http/receiver_binary.js
@@ -52,6 +52,11 @@ BinaryHTTPReceiver.prototype.check = function(payload, headers) {
   // Clone and low case all headers names
   const sanityHeaders = Commons.sanityAndClone(headers);
 
+  // If no content type is provided, default to application/json
+  if (!sanityHeaders[Constants.HEADER_CONTENT_TYPE]) {
+    sanityHeaders[Constants.HEADER_CONTENT_TYPE] = Constants.MIME_JSON;
+  }
+
   // Validation Level 1
   if (!this.allowedContentTypes
     .includes(sanityHeaders[Constants.HEADER_CONTENT_TYPE])) {

--- a/test/bindings/http/receiver_binary_0_3_tests.js
+++ b/test/bindings/http/receiver_binary_0_3_tests.js
@@ -144,6 +144,20 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v0.3", () => {
       expect(receiver.check.bind(receiver, payload, attributes))
         .to.not.throw();
     });
+
+    it("No error when content-type is unspecified", () => {
+      const payload = {};
+      const attributes = {
+        "ce-type": "type",
+        "ce-specversion": "0.3",
+        "ce-source": "source",
+        "ce-id": "id"
+      };
+
+      // act and assert
+      expect(receiver.check.bind(receiver, payload, attributes))
+        .to.not.throw();
+    });
   });
 
   describe("Parse", () => {

--- a/test/bindings/http/receiver_binary_1_tests.js
+++ b/test/bindings/http/receiver_binary_1_tests.js
@@ -130,6 +130,20 @@ describe("HTTP Transport Binding Binary Receiver for CloudEvents v1.0", () => {
         .to.throw("invalid content type");
     });
 
+    it("No error when content-type is unspecified", () => {
+      const payload = {};
+      const attributes = {
+        "ce-type": "type",
+        "ce-specversion": "1.0",
+        "ce-source": "source",
+        "ce-id": "id"
+      };
+
+      // act and assert
+      expect(receiver.check.bind(receiver, payload, attributes))
+        .to.not.throw();
+    });
+
     it("No error when all required headers are in place", () => {
       // setup
       const payload = {};


### PR DESCRIPTION
The Knative Kafka event source does not include a `Content-Type` header when
sending binary events. The CE HTTP binding specification doesn't address how
a receiver should handle this situation.

This commit makes `application/json` the default.

Fixes: https://github.com/cloudevents/sdk-javascript/issues/117
Ref: https://github.com/cloudevents/spec/issues/614

Signed-off-by: Lance Ball <lball@redhat.com>