### PR TITLE
lib: remove mode variable from getMode

### DIFF
--- a/lib/bindings/http/http_receiver.js
+++ b/lib/bindings/http/http_receiver.js
@@ -42,16 +42,14 @@ class HTTPReceiver {
 }
 
 function getMode(headers) {
-  let mode = "unknown";
   const contentType = headers[HEADER_CONTENT_TYPE];
   if (contentType && contentType.startsWith(MIME_CE)) {
-    mode = "structured";
-  } else if (headers[BINARY_HEADERS_1.ID]) {
-    mode = "binary";
-  } else {
-    throw new TypeError("no cloud event detected");
+    return "structured";
   }
-  return mode;
+  if (headers[BINARY_HEADERS_1.ID]) {
+    return "binary";
+  }
+  throw new TypeError("no cloud event detected");
 }
 
 function getVersion(mode, headers, body) {


### PR DESCRIPTION
Currently, the mode variable in getMode is set to 'unknown' but this
will never get returned as the else clause will throw a TypeError if the
detected mode (from the passed-in headers) is not structured or binary.

This commit suggests simplifying the getMode function and removes the
mode variable.

Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>