### PR TITLE
lib: add .js suffix to receiver_binary_0_3

### DIFF
--- a/lib/bindings/http/http_receiver.js
+++ b/lib/bindings/http/http_receiver.js
@@ -1,4 +1,4 @@
-const V03Binary = require("./receiver_binary_0_3");
+const V03Binary = require("./receiver_binary_0_3.js");
 const V03Structured = require("./receiver_structured_0_3.js");
 const V1Binary = require("./receiver_binary_1.js");
 const V1Structured = require("./receiver_structured_1.js");


### PR DESCRIPTION
This commit adds the '.js' suffix to the require of receiver_binary_0_3
to be consistent with the other requires statments in this file.

Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>