### PR TITLE
test: remove uuid require in spec_03_tests.js

### DIFF
--- a/test/spec_0_3_tests.js
+++ b/test/spec_0_3_tests.js
@@ -1,9 +1,8 @@
 const expect = require("chai").expect;
 const Spec03 = require("../lib/specs/spec_0_3.js");
 const { CloudEvent } = require("../index.js");
-const { v4: uuidv4 } = require("uuid");
 
-const id = uuidv4();
+const id = "97699ec2-a8d9-47c1-bfa0-ff7aa526f838";
 const type = "com.github.pull.create";
 const source = "urn:event:from:myapi/resourse/123";
 const time = new Date();


### PR DESCRIPTION
This commit removes the require of uuid from this test and uses a
hardcoded value for the 'id' constant instead.

The motivation for this is that the value for 'id' does not need to be
generated for each test run, and fewer requires helps readabilitly I
find.

Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>