### PR TITLE
lib: remove unnecessary else statements

### DIFF
--- a/lib/bindings/http/unmarshaller.js
+++ b/lib/bindings/http/unmarshaller.js
@@ -22,21 +22,21 @@ function resolveBindingName(payload, headers) {
     // Structured
     if (allowedStructuredContentTypes.includes(contentType)) {
       return STRUCTURED;
-    } else {
-      const err = new TypeError("structured+type not allowed");
-      err.errors = [contentType];
-      throw err;
     }
+    throwTypeError("structured+type not allowed", contentType);
   } else {
     // Binary
     if (allowedBinaryContentTypes.includes(contentType)) {
       return BINARY;
-    } else {
-      const err = new TypeError("content type not allowed");
-      err.errors = [contentType];
-      throw err;
     }
+    throwTypeError("content type not allowed", contentType);
   }
+}
+
+function throwTypeError(msg, contentType) {
+  const err = new TypeError(msg);
+  err.errors = [contentType];
+  throw err;
 }
 
 class Unmarshaller {


### PR DESCRIPTION
This commit removes two unnecessary else clauses in unmarshaller.js, and
also extracts the throwing of TypeError of invalid content types into a
separate function to avoid some code duplication.

Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>