### PR TITLE
lib: make setterByAttribute a Map

### DIFF
--- a/lib/bindings/http/receiver_structured.js
+++ b/lib/bindings/http/receiver_structured.js
@@ -23,11 +23,11 @@ function validateArgs(payload, attributes) {
 
 function StructuredHTTPReceiver(
   parserByMime,
-  setterByAttribute,
+  parserMap,
   allowedContentTypes,
   Spec) {
   this.parserByMime = parserByMime;
-  this.setterByAttribute = setterByAttribute;
+  this.parserMap = parserMap;
   this.allowedContentTypes = allowedContentTypes;
   this.Spec = Spec;
   this.spec = new Spec();
@@ -63,18 +63,15 @@ StructuredHTTPReceiver.prototype.parse = function(payload, headers) {
   const processedAttributes = [];
   const cloudevent = new CloudEvent(this.Spec);
 
-  Array.from(Object.keys(this.setterByAttribute))
-    .filter((attribute) => event[attribute])
-    .forEach((attribute) => {
-      const setterName = this.setterByAttribute[attribute].name;
-      const parserFun = this.setterByAttribute[attribute].parser;
-
+  this.parserMap.forEach((value, key) => {
+    if (event[key]) {
       // invoke the setter function
-      cloudevent[setterName](parserFun(event[attribute]));
+      cloudevent[value.name](value.parser(event[key]));
 
       // to use ahead, for extensions processing
-      processedAttributes.push(attribute);
-    });
+      processedAttributes.push(key);
+    }
+  });
 
   // Every unprocessed attribute should be an extension
   Array.from(Object.keys(event))

--- a/lib/bindings/http/receiver_structured_0_3.js
+++ b/lib/bindings/http/receiver_structured_0_3.js
@@ -1,3 +1,19 @@
+const {
+  MIME_JSON,
+  MIME_CE_JSON,
+  STRUCTURED_ATTRS_03 : {
+    TYPE,
+    SPEC_VERSION,
+    SOURCE,
+    ID,
+    TIME,
+    SCHEMA_URL,
+    CONTENT_ENCODING,
+    CONTENT_TYPE,
+    SUBJECT,
+    DATA
+  }
+} = require("./constants.js");
 const Constants = require("./constants.js");
 const Spec = require("../../specs/spec_0_3.js");
 const JSONParser = require("../../formats/json/parser.js");
@@ -7,60 +23,35 @@ const StructuredHTTPReceiver = require("./receiver_structured.js");
 const jsonParserSpec = new JSONParser();
 
 const parserByMime = {};
-parserByMime[Constants.MIME_JSON] = jsonParserSpec;
-parserByMime[Constants.MIME_CE_JSON] = jsonParserSpec;
+parserByMime[MIME_JSON] = jsonParserSpec;
+parserByMime[MIME_CE_JSON] = jsonParserSpec;
 
 const allowedContentTypes = [];
-allowedContentTypes.push(Constants.MIME_CE_JSON);
+allowedContentTypes.push(MIME_CE_JSON);
 
-const setterByAttribute = {};
-setterByAttribute[Constants.STRUCTURED_ATTRS_03.TYPE] = {
-  name: "type",
-  parser: (v) => v
-};
-setterByAttribute[Constants.STRUCTURED_ATTRS_03.SPEC_VERSION] = {
-  name: "specversion",
-  parser: (v) => v
-};
-setterByAttribute[Constants.STRUCTURED_ATTRS_03.SOURCE] = {
-  name: "source",
-  parser: (v) => v
-};
-setterByAttribute[Constants.STRUCTURED_ATTRS_03.ID] = {
-  name: "id",
-  parser: (v) => v
-};
-setterByAttribute[Constants.STRUCTURED_ATTRS_03.TIME] = {
-  name: "time",
-  parser: (v) => new Date(Date.parse(v))
-};
-setterByAttribute[Constants.STRUCTURED_ATTRS_03.SCHEMA_URL] = {
-  name: "schemaurl",
-  parser: (v) => v
-};
-setterByAttribute[Constants.STRUCTURED_ATTRS_03.CONTENT_ENCONDING] = {
-  name: "dataContentEncoding",
-  parser: (v) => v
-};
-setterByAttribute[Constants.STRUCTURED_ATTRS_03.CONTENT_TYPE] = {
-  name: "dataContentType",
-  parser: (v) => v
-};
-setterByAttribute[Constants.STRUCTURED_ATTRS_03.SUBJECT] = {
-  name: "subject",
-  parser: (v) => v
-};
-setterByAttribute[Constants.STRUCTURED_ATTRS_03.DATA] = {
-  name: "data",
-  parser: (v) => v
-};
+function parser(name, parser = (v) => v) {
+  return { name: name, parser: parser};
+}
+const passThroughParser = parser;
+
+const parserMap = new Map();
+parserMap.set(TYPE, passThroughParser("type"));
+parserMap.set(SPEC_VERSION, passThroughParser("specversion"));
+parserMap.set(SOURCE, passThroughParser("source"));
+parserMap.set(ID, passThroughParser("id"));
+parserMap.set(TIME, parser("time", (v) => new Date(Date.parse(v))));
+parserMap.set(SCHEMA_URL, passThroughParser("schemaurl"));
+parserMap.set(CONTENT_ENCODING, passThroughParser("dataContentEncoding"));
+parserMap.set(CONTENT_TYPE, passThroughParser("dataContentType"));
+parserMap.set(SUBJECT, passThroughParser("subject"));
+parserMap.set(DATA, passThroughParser("data"));
 
 // Leaving this in place for now. TODO: fixme
 // eslint-disable-next-line
 function Receiver(configuration) {
   this.receiver = new StructuredHTTPReceiver(
     parserByMime,
-    setterByAttribute,
+    parserMap,
     allowedContentTypes,
     Spec
   );

--- a/lib/bindings/http/receiver_structured_1.js
+++ b/lib/bindings/http/receiver_structured_1.js
@@ -1,4 +1,20 @@
-const Constants = require("./constants.js");
+const {
+  MIME_JSON,
+  MIME_CE_JSON,
+  STRUCTURED_ATTRS_1 : {
+    TYPE,
+    SPEC_VERSION,
+    SOURCE,
+    ID,
+    TIME,
+    DATA_SCHEMA,
+    CONTENT_TYPE,
+    SUBJECT,
+    DATA,
+    DATA_BASE64
+  }
+} = require("./constants.js");
+
 const Spec = require("../../specs/spec_1.js");
 const JSONParser = require("../../formats/json/parser.js");
 
@@ -7,60 +23,35 @@ const StructuredHTTPReceiver = require("./receiver_structured.js");
 const jsonParserSpec = new JSONParser();
 
 const parserByMime = {};
-parserByMime[Constants.MIME_JSON] = jsonParserSpec;
-parserByMime[Constants.MIME_CE_JSON] = jsonParserSpec;
+parserByMime[MIME_JSON] = jsonParserSpec;
+parserByMime[MIME_CE_JSON] = jsonParserSpec;
 
 const allowedContentTypes = [];
-allowedContentTypes.push(Constants.MIME_CE_JSON);
+allowedContentTypes.push(MIME_CE_JSON);
 
-const setterByAttribute = {};
-setterByAttribute[Constants.STRUCTURED_ATTRS_1.TYPE] = {
-  name: "type",
-  parser: (v) => v
-};
-setterByAttribute[Constants.STRUCTURED_ATTRS_1.SPEC_VERSION] = {
-  name: "specversion",
-  parser: (v) => v
-};
-setterByAttribute[Constants.STRUCTURED_ATTRS_1.SOURCE] = {
-  name: "source",
-  parser: (v) => v
-};
-setterByAttribute[Constants.STRUCTURED_ATTRS_1.ID] = {
-  name: "id",
-  parser: (v) => v
-};
-setterByAttribute[Constants.STRUCTURED_ATTRS_1.TIME] = {
-  name: "time",
-  parser: (v) => new Date(Date.parse(v))
-};
-setterByAttribute[Constants.STRUCTURED_ATTRS_1.DATA_SCHEMA] = {
-  name: "dataschema",
-  parser: (v) => v
-};
-setterByAttribute[Constants.STRUCTURED_ATTRS_1.CONTENT_TYPE] = {
-  name: "dataContentType",
-  parser: (v) => v
-};
-setterByAttribute[Constants.STRUCTURED_ATTRS_1.SUBJECT] = {
-  name: "subject",
-  parser: (v) => v
-};
-setterByAttribute[Constants.STRUCTURED_ATTRS_1.DATA] = {
-  name: "data",
-  parser: (v) => v
-};
-setterByAttribute[Constants.STRUCTURED_ATTRS_1.DATA_BASE64] = {
-  name: "data",
-  parser: (v) => v
-};
+function parser(name, parser = (v) => v) {
+  return { name: name, parser: parser};
+}
+const passThroughParser = parser;
+
+const parserMap = new Map();
+parserMap.set(TYPE, passThroughParser("type"));
+parserMap.set(SPEC_VERSION, passThroughParser("specversion"));
+parserMap.set(SOURCE, passThroughParser("source"));
+parserMap.set(ID, passThroughParser("id"));
+parserMap.set(TIME, parser("time", (v) => new Date(Date.parse(v))));
+parserMap.set(DATA_SCHEMA, passThroughParser("dataschema"));
+parserMap.set(CONTENT_TYPE, passThroughParser("dataContentType"))
+parserMap.set(SUBJECT, passThroughParser("subject"));
+parserMap.set(DATA, passThroughParser("data"));
+parserMap.set(DATA_BASE64, passThroughParser("data"));
 
 // Leaving this in place for now. TODO: fixme
 // eslint-disable-next-line
 function Receiver(configuration) {
   this.receiver = new StructuredHTTPReceiver(
     parserByMime,
-    setterByAttribute,
+    parserMap,
     allowedContentTypes,
     Spec
   );


### PR DESCRIPTION
This commit changes the setterByAttribute to be a map and tries to
reduce some code duplication and improve readability.

Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>