### PR TITLE
lib: remove version variable from getVersion

### DIFF
--- a/lib/bindings/http/http_receiver.js
+++ b/lib/bindings/http/http_receiver.js
@@ -68,18 +68,18 @@ function getMode(headers) {
 }
 
 function getVersion(mode, headers, body) {
-  let version = SPEC_V1; // default to 1.0
-
   if (mode === "binary") {
     // Check the headers for the version
     const versionHeader = headers[DEFAULT_SPEC_VERSION_HEADER];
-    if (versionHeader) { version = versionHeader; }
+    if (versionHeader) {
+      return versionHeader;
+    }
   } else {
     // structured mode - the version is in the body
-    version = body instanceof String
+    return body instanceof String
       ? JSON.parse(body).specversion : body.specversion;
   }
-  return version;
+  return SPEC_V1;
 }
 
 module.exports = HTTPReceiver;


### PR DESCRIPTION
This commit removes the `version` variable from `getVersion` and updates the
code to use return statements to be consitent with other functions in
this file, like `getMode` and `accept`.

Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>