### PR TITLE
lib: remove result variable from asData

### DIFF
--- a/lib/utils/fun.js
+++ b/lib/utils/fun.js
@@ -53,20 +53,16 @@ const isJsonContentType = (contentType) =>
   contentType && contentType.match(/(json)/i);
 
 const asData = (data, contentType) => {
-  let result = data;
-
   // pattern matching alike
-  result = isString(result) &&
-    !isBase64(result) &&
+  const maybeJson = isString(data) &&
+    !isBase64(data) &&
     isJsonContentType(contentType)
-    ? JSON.parse(result)
-    : result;
+    ? JSON.parse(data)
+    : data;
 
-  result = isBinary(result)
-    ? asBase64(result)
-    : result;
-
-  return result;
+  return isBinary(maybeJson)
+    ? asBase64(maybeJson)
+    : maybeJson;
 };
 
 module.exports = {


### PR DESCRIPTION
This commit removes the 'result' variable form the utility function
asData. The motivation is to improve readability.

Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>