### PR TITLE
lib: make headerByGetter a Map

### DIFF
--- a/lib/bindings/http/emitter_binary.js
+++ b/lib/bindings/http/emitter_binary.js
@@ -34,10 +34,10 @@ class BinaryHTTPEmitter {
    */
   constructor(version) {
     if (version === SPEC_V1) {
-      this.headerByGetter = EmitterV1;
+      this.headerParserMap = EmitterV1;
       this.extensionPrefix = BINARY_HEADERS_1.EXTENSIONS_PREFIX;
     } else if (version === SPEC_V03) {
-      this.headerByGetter = EmitterV3;
+      this.headerParserMap = EmitterV3;
       this.extensionPrefix = BINARY_HEADERS_03.EXTENSIONS_PREFIX;
     }
   }
@@ -56,12 +56,12 @@ class BinaryHTTPEmitter {
     const config = { ...options, ...defaults };
     const headers = config[HEADERS];
 
-    Object.keys(this.headerByGetter)
-      .filter((getter) => cloudevent[getter]())
-      .forEach((getter) => {
-        const header = this.headerByGetter[getter];
-        headers[header.name] = header.parser(cloudevent[getter]());
-      });
+    this.headerParserMap.forEach((parser, getterName) => {
+      const value = cloudevent[getterName]();
+      if (value) {
+        headers[parser.headerName] = parser.parse(value);
+      }
+    });
 
     // Set the cloudevent payload
     const formatted = cloudevent.format();

--- a/lib/bindings/http/http_emitter.js
+++ b/lib/bindings/http/http_emitter.js
@@ -77,12 +77,12 @@ class HTTPEmitter {
   headers(event) {
     const headers = {};
 
-    Object.keys(this.binary.headerByGetter)
-      .filter((getter) => event[getter]())
-      .forEach((getter) => {
-        const header = this.binary.headerByGetter[getter];
-        headers[header.name] = header.parser(event[getter]());
-      });
+    this.binary.headerParserMap.forEach((parser, getterName) => {
+      const value = event[getterName]();
+      if (value) {
+        headers[parser.headerName] = parser.parse(value);
+      }
+    });
 
     return headers;
   }

--- a/lib/bindings/http/v03/emitter_binary_0_3.js
+++ b/lib/bindings/http/v03/emitter_binary_0_3.js
@@ -1,59 +1,35 @@
 const {
   HEADER_CONTENT_TYPE,
-  BINARY_HEADERS_03
+  BINARY_HEADERS_03 : {
+   CONTENT_ENCODING,
+   SUBJECT,
+   TYPE,
+   SPEC_VERSION,
+   SOURCE,
+   ID,
+   TIME,
+   SCHEMA_URL
+  }
 } = require("../constants.js");
 
-const passThroughParser = (v) => v;
+function parser(header, parser = (v) => v) {
+  return { headerName: header, parse: parser };
+}
+const passThroughParser = parser;
 
 /**
- * A utility object used to retrieve the header names for a CloudEvent
+ * A utility Map used to retrieve the header names for a CloudEvent
  * using the CloudEvent getter function.
  */
-const headerByGetter = {
-  getDataContentType: {
-    name: HEADER_CONTENT_TYPE,
-    parser: passThroughParser
-  },
+const headerMap = new Map();
+headerMap.set('getDataContentType', passThroughParser(HEADER_CONTENT_TYPE));
+headerMap.set('getDataContentEncoding', passThroughParser(CONTENT_ENCODING));
+headerMap.set('getSubject', passThroughParser(SUBJECT));
+headerMap.set('getType', passThroughParser(TYPE));
+headerMap.set('getSpecversion', passThroughParser(SPEC_VERSION));
+headerMap.set('getSource', passThroughParser(SOURCE));
+headerMap.set('getId', passThroughParser(ID));
+headerMap.set('getTime', passThroughParser(TIME));
+headerMap.set('getSchemaurl', passThroughParser(SCHEMA_URL));
 
-  getDataContentEncoding: {
-    name: BINARY_HEADERS_03.CONTENT_ENCODING,
-    parser: passThroughParser
-  },
-
-  getSubject: {
-    name: BINARY_HEADERS_03.SUBJECT,
-    parser: passThroughParser
-  },
-
-  getType: {
-    name: BINARY_HEADERS_03.TYPE,
-    parser: passThroughParser
-  },
-
-  getSpecversion: {
-    name: BINARY_HEADERS_03.SPEC_VERSION,
-    parser: passThroughParser
-  },
-
-  getSource: {
-    name: BINARY_HEADERS_03.SOURCE,
-    parser: passThroughParser
-  },
-
-  getId: {
-    name: BINARY_HEADERS_03.ID,
-    parser: passThroughParser
-  },
-
-  getTime: {
-    name: BINARY_HEADERS_03.TIME,
-    parser: passThroughParser
-  },
-
-  getSchemaurl: {
-    name: BINARY_HEADERS_03.SCHEMA_URL,
-    parser: passThroughParser
-  }
-};
-
-module.exports = headerByGetter;
+module.exports = headerMap;

--- a/lib/bindings/http/v1/emitter_binary_1.js
+++ b/lib/bindings/http/v1/emitter_binary_1.js
@@ -1,54 +1,33 @@
 const {
   HEADER_CONTENT_TYPE,
-  BINARY_HEADERS_1
+  BINARY_HEADERS_1 : {
+   SUBJECT,
+   TYPE,
+   SPEC_VERSION,
+   SOURCE,
+   ID,
+   TIME,
+   DATA_SCHEMA
+ }
 } = require("../constants.js");
 
-const passThroughParser = (v) => v;
+function parser(header, parser = v => v) {
+  return { headerName: header, parse: parser };
+}
+const passThroughParser = parser;
 
 /**
- * A utility object used to retrieve the header names for a CloudEvent
+ * A utility Map used to retrieve the header names for a CloudEvent
  * using the CloudEvent getter function.
  */
-const headerByGetter = {
-  getDataContentType: {
-    name: HEADER_CONTENT_TYPE,
-    parser: passThroughParser
-  },
+const headerMap = new Map();
+headerMap.set('getDataContentType', passThroughParser(HEADER_CONTENT_TYPE));
+headerMap.set('getSubject', passThroughParser(SUBJECT));
+headerMap.set('getType', passThroughParser(TYPE));
+headerMap.set('getSpecversion', passThroughParser(SPEC_VERSION));
+headerMap.set('getSource', passThroughParser(SOURCE));
+headerMap.set('getId', passThroughParser(ID));
+headerMap.set('getTime', passThroughParser(TIME));
+headerMap.set('getDataschema', passThroughParser(DATA_SCHEMA));
 
-  getSubject: {
-    name: BINARY_HEADERS_1.SUBJECT,
-    parser: passThroughParser
-  },
-
-  getType: {
-    name: BINARY_HEADERS_1.TYPE,
-    parser: passThroughParser
-  },
-
-  getSpecversion: {
-    name: BINARY_HEADERS_1.SPEC_VERSION,
-    parser: passThroughParser
-  },
-
-  getSource: {
-    name: BINARY_HEADERS_1.SOURCE,
-    parser: passThroughParser
-  },
-
-  getId: {
-    name: BINARY_HEADERS_1.ID,
-    parser: passThroughParser
-  },
-
-  getTime: {
-    name: BINARY_HEADERS_1.TIME,
-    parser: passThroughParser
-  },
-
-  getDataschema: {
-    name: BINARY_HEADERS_1.DATA_SCHEMA,
-    parser: passThroughParser
-  }
-};
-
-module.exports = headerByGetter;
+module.exports = headerMap;


### PR DESCRIPTION
This commit turns the `headerByGetter` Object into a `Map` to reduces some
code duplication an hopefully improve readability a little.

Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>