### PR TITLE
docs: link to 1.0 README until 2.0 is published

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ versions of the CloudEvent specification.
 
 ## Usage
 
+**NOTE: The examples below are for the current codebase on `master`. If you are using the 1.0.0 npm
+module, please see the [v1.0 README](https://github.com/cloudevents/sdk-javascript/blob/v1.0.0/README.md#how-to-use).**
+
 **See the full working example: [here](./examples/express-ex).**
 
 ### Installation


### PR DESCRIPTION
The README currently has usage documentation for an unreleased version of this module. It should be updated to link to the existing 1.0 usage doc in the readme. 

Fixes: https://github.com/cloudevents/sdk-javascript/issues/174

Signed-off-by: Lance Ball <lball@redhat.com>