### PR TITLE
lib: make HTTPEmitter headers method a property of the class

### DIFF
--- a/lib/bindings/http/http_emitter.js
+++ b/lib/bindings/http/http_emitter.js
@@ -1,5 +1,7 @@
 const BinaryHTTPEmitter = require("./emitter_binary.js");
 const StructuredEmitter = require("./emitter_structured.js");
+const EmitterV1 = require("./v1").BinaryEmitter;
+const EmitterV03 = require("./v03").BinaryEmitter;
 
 /** @typedef {import("../../cloudevent")} CloudEvent */
 
@@ -66,26 +68,33 @@ class HTTPEmitter {
     }
     throw new TypeError(`Unknown transport mode ${mode}.`);
   }
-
-  /**
-   * Returns the HTTP headers that will be sent for this event when the HTTP transmission
-   * mode is "binary". Events sent over HTTP in structured mode only have a single CE header
-   * and that is "ce-id", corresponding to the event ID.
-   * @param {CloudEvent} event a CloudEvent
-   * @returns {Object} the headers that will be sent for the event
-   */
-  headers(event) {
-    const headers = {};
-
-    this.binary.headerParserMap.forEach((parser, getterName) => {
-      const value = event[getterName];
-      if (value) {
-        headers[parser.headerName] = parser.parse(value);
-      }
-    });
-
-    return headers;
-  }
 }
 
+/**
+ * Returns the HTTP headers that will be sent for this event when the HTTP transmission
+ * mode is "binary". Events sent over HTTP in structured mode only have a single CE header
+ * and that is "ce-id", corresponding to the event ID.
+ * @param {CloudEvent} event a CloudEvent
+ * @param {string} [version] spec version number - default 1.0
+ * @returns {Object} the headers that will be sent for the event
+ */
+function headers(event, version = SPEC_V1) {
+  const headers = {};
+  let headerMap;
+  if (version === SPEC_V1) {
+    headerMap = EmitterV1;
+  } else if (version === SPEC_V03) {
+    headerMap = EmitterV03;
+  }
+  headerMap.forEach((parser, getterName) => {
+    const value = event[getterName];
+    if (value) {
+      headers[parser.headerName] = parser.parse(value);
+    }
+  });
+
+  return headers;
+}
+
+HTTPEmitter.headers = headers;
 module.exports = HTTPEmitter;

--- a/test/bindings/http/http_emitter_test.js
+++ b/test/bindings/http/http_emitter_test.js
@@ -11,9 +11,6 @@ const {
 
 const { CloudEvent, HTTPEmitter } = require("../../../");
 
-const V1Spec = require("../../../lib/bindings/http/v1").Spec;
-const V03Spec = require("../../../lib/bindings/http/v03").Spec;
-
 const receiver = "https://cloudevents.io/";
 const type = "com.example.test";
 const source = "urn:event:from:myapi/resource/123";
@@ -67,7 +64,7 @@ describe("HTTP Transport Binding Emitter for CloudEvents", () => {
     });
 
     it("Provides the HTTP headers for a binary event", () => {
-      const headers = emitter.headers(event);
+      const headers = HTTPEmitter.headers(event);
       expect(headers[BINARY_HEADERS_1.TYPE]).to.equal(event.type);
       expect(headers[BINARY_HEADERS_1.SPEC_VERSION]).to.equal(event.specversion);
       expect(headers[BINARY_HEADERS_1.SOURCE]).to.equal(event.source);
@@ -140,7 +137,7 @@ describe("HTTP Transport Binding Emitter for CloudEvents", () => {
     });
 
     it("Provides the HTTP headers for a binary event", () => {
-      const headers = emitter.headers(event);
+      const headers = HTTPEmitter.headers(event, SPEC_V03);
       expect(headers[BINARY_HEADERS_03.TYPE]).to.equal(event.type);
       expect(headers[BINARY_HEADERS_03.SPEC_VERSION]).to.equal(event.specversion);
       expect(headers[BINARY_HEADERS_03.SOURCE]).to.equal(event.source);


### PR DESCRIPTION
Now, instead of requiring an instance of HTTPEmitter to retrieve the headers
for an event, you can get them this way:

```js
const headers = HTTPEmitter.headers(myCloudEvent);
```

Fixes: https://github.com/cloudevents/sdk-javascript/issues/178