### PR TITLE
fix: use /lib in gitignore so src/lib is not ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ yarn-error.log*
 # Generated files
 *.d.ts
 index.js
-lib
+/lib
 
 # Runtime data
 pids


### PR DESCRIPTION
Signed-off-by: Lance Ball <lball@redhat.com>