### PR TITLE
fix: fix references to constants - remove .js extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ yarn-error.log*
 # Generated files
 *.d.ts
 index.js
-lib
+/lib
 
 # Runtime data
 pids

--- a/src/lib/bindings/http/emitter_binary.js
+++ b/src/lib/bindings/http/emitter_binary.js
@@ -11,7 +11,7 @@ const {
   DATA_ATTRIBUTE,
   SPEC_V1,
   SPEC_V03
-} = require("./constants.js");
+} = require("./constants");
 
 const defaults = {
   [HEADERS]: {

--- a/src/lib/bindings/http/emitter_structured.js
+++ b/src/lib/bindings/http/emitter_structured.js
@@ -7,7 +7,7 @@ const {
   DEFAULT_CE_CONTENT_TYPE,
   HEADERS,
   HEADER_CONTENT_TYPE
-} = require("./constants.js");
+} = require("./constants");
 
 const defaults = {
   [HEADERS]: {

--- a/src/lib/bindings/http/receiver_binary.js
+++ b/src/lib/bindings/http/receiver_binary.js
@@ -1,7 +1,7 @@
 const ReceiverV1 = require("./v1/receiver_binary_1.js");
 const ReceiverV3 = require("./v03/receiver_binary_0_3.js");
 
-const { SPEC_V03, SPEC_V1 } = require("./constants.js");
+const { SPEC_V03, SPEC_V1 } = require("./constants");
 const { check, parse } = require("./validation/binary.js");
 
 /** @typedef {import("../../cloudevent")} CloudEvent */

--- a/src/lib/bindings/http/receiver_structured.js
+++ b/src/lib/bindings/http/receiver_structured.js
@@ -1,7 +1,7 @@
 const ReceiverV1 = require("./v1/receiver_structured_1.js");
 const ReceiverV3 = require("./v03/receiver_structured_0_3.js");
 
-const { SPEC_V03, SPEC_V1 } = require("./constants.js");
+const { SPEC_V03, SPEC_V1 } = require("./constants");
 const { check, parse } = require("./validation/structured.js");
 
 /** @typedef {import("../../cloudevent")} CloudEvent */

--- a/src/lib/bindings/http/v03/emitter_binary_0_3.js
+++ b/src/lib/bindings/http/v03/emitter_binary_0_3.js
@@ -10,7 +10,7 @@ const {
    TIME,
    SCHEMA_URL
   }
-} = require("../constants.js");
+} = require("../constants");
 
 function parser(header, parser = (v) => v) {
   return { headerName: header, parse: parser };

--- a/src/lib/bindings/http/v03/receiver_binary_0_3.js
+++ b/src/lib/bindings/http/v03/receiver_binary_0_3.js
@@ -5,7 +5,7 @@ const {
   ENCODING_BASE64,
   HEADER_CONTENT_TYPE,
   BINARY_HEADERS_03
-} = require("../constants.js");
+} = require("../constants");
 const Spec = require("./spec_0_3.js");
 
 const JSONParser = require("../../../formats/json/parser.js");

--- a/src/lib/bindings/http/v03/receiver_structured_0_3.js
+++ b/src/lib/bindings/http/v03/receiver_structured_0_3.js
@@ -13,7 +13,7 @@ const {
     SUBJECT,
     DATA
   }
-} = require("../constants.js");
+} = require("../constants");
 const Spec = require("./spec_0_3.js");
 const JSONParser = require("../../../formats/json/parser.js");
 

--- a/src/lib/bindings/http/v1/emitter_binary_1.js
+++ b/src/lib/bindings/http/v1/emitter_binary_1.js
@@ -9,7 +9,7 @@ const {
    TIME,
    DATA_SCHEMA
  }
-} = require("../constants.js");
+} = require("../constants");
 
 function parser(header, parser = (v) => v) {
   return { headerName: header, parse: parser };

--- a/src/lib/bindings/http/v1/receiver_structured_1.js
+++ b/src/lib/bindings/http/v1/receiver_structured_1.js
@@ -13,7 +13,7 @@ const {
     DATA_BASE64,
     MIME_JSON
   }
-} = require("../constants.js");
+} = require("../constants");
 
 const Spec = require("./spec_1.js");
 const JSONParser = require("../../../formats/json/parser.js");

--- a/src/lib/bindings/http/validation/binary.js
+++ b/src/lib/bindings/http/validation/binary.js
@@ -9,7 +9,7 @@ const {
   HEADER_CONTENT_TYPE,
   MIME_JSON,
   DEFAULT_SPEC_VERSION_HEADER
-} = require("../constants.js");
+} = require("../constants");
 
 const {
   isString,

--- a/src/lib/bindings/http/validation/commons.js
+++ b/src/lib/bindings/http/validation/commons.js
@@ -1,5 +1,5 @@
 const ValidationError = require("./validation_error.js");
-const Constants = require("../constants.js");
+const Constants = require("../constants");
 const {
   isDefinedOrThrow,
   isStringOrObjectOrThrow

--- a/src/lib/bindings/http/validation/structured.js
+++ b/src/lib/bindings/http/validation/structured.js
@@ -6,7 +6,7 @@ const {
 } = require("./commons.js");
 const {
   HEADER_CONTENT_TYPE
-} = require("../constants.js");
+} = require("../constants");
 
 function check(payload, headers, receiver) {
   validateArgs(payload, headers);

--- a/src/lib/cloudevent.ts
+++ b/src/lib/cloudevent.ts
@@ -6,7 +6,7 @@ import Spec03 from "./bindings/http/v03/spec_0_3.js";
 import Formatter from "./formats/json/formatter.js";
 import { isBinary } from "./bindings/http/validation/fun.js";
 
-const { SPEC_V1, SPEC_V03 } = require("./bindings/http/constants.js");
+const { SPEC_V1, SPEC_V03 } = require("./bindings/http/constants");
 
 export type CE = CloudEventV1 | CloudEventV1Attributes | CloudEventV03 | CloudEventV03Attributes
 


### PR DESCRIPTION
Even though `constants.js` will work just fine here, since that file is ultimately generated, having the `.js` extension in the `/src` tree confuses some tools - e.g. `ts-loader` for webpack.

Signed-off-by: Lance Ball <lball@redhat.com>