### PR TITLE
fix: add correct types to improve usage in TypeScript projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudevents-sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -318,44 +318,6 @@
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
     },
-    "@paztis/typedoc": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@paztis/typedoc/-/typedoc-0.1.6.tgz",
-      "integrity": "sha512-C6ywLbqa81u0FV907QrUHxYbi6n4lJyD7vCcmpVXZvShTfALT8NmeLLhMaLuAd8h3kl4N/Kkr3MSJpeCFjy5yQ==",
-      "dev": true,
-      "requires": {
-        "@types/minimatch": "3.0.3",
-        "fs-extra": "^8.1.0",
-        "handlebars": "^4.7.2",
-        "highlight.js": "^9.18.0",
-        "lodash": "^4.17.15",
-        "marked": "^0.8.0",
-        "minimatch": "^3.0.0",
-        "progress": "^2.0.3",
-        "shelljs": "^0.8.3",
-        "typedoc-default-themes": "0.8.0-0"
-      },
-      "dependencies": {
-        "highlight.js": {
-          "version": "9.18.1",
-          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.1.tgz",
-          "integrity": "sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==",
-          "dev": true
-        },
-        "typedoc-default-themes": {
-          "version": "0.8.0-0",
-          "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.8.0-0.tgz",
-          "integrity": "sha512-blFWppm5aKnaPOa1tpGO9MLu+njxq7P3rtkXK4QxJBNszA+Jg7x0b+Qx0liXU1acErur6r/iZdrwxp5DUFdSXw==",
-          "dev": true,
-          "requires": {
-            "backbone": "^1.4.0",
-            "jquery": "^3.4.1",
-            "lunr": "^2.3.8",
-            "underscore": "^1.9.1"
-          }
-        }
-      }
-    },
     "@types/ajv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/ajv/-/ajv-1.0.0.tgz",
@@ -374,22 +336,28 @@
         "axios": "*"
       }
     },
+    "@types/chai": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
+      "integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
+      "dev": true
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
-    "@types/minimatch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-      "dev": true
-    },
     "@types/minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
+      "dev": true
+    },
+    "@types/mocha": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
+      "integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
       "dev": true
     },
     "@types/node": {
@@ -516,6 +484,12 @@
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
     },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -582,15 +556,6 @@
       "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
       "requires": {
         "follow-redirects": "1.5.10"
-      }
-    },
-    "backbone": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
-      "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
-      "dev": true,
-      "requires": {
-        "underscore": ">=1.8.3"
       }
     },
     "balanced-match": {
@@ -2981,6 +2946,12 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "highlight.js": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.0.3.tgz",
+      "integrity": "sha512-9FG7SSzv9yOY5CGGxfI6NDm7xLYtMOjKtPBxw7Zff3t5UcRcUNTGEeS8lNjhceL34KeetLMoGMFTGoaa83HwyQ==",
+      "dev": true
+    },
     "hosted-git-info": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
@@ -3454,12 +3425,6 @@
         "istanbul-lib-report": "^3.0.0"
       }
     },
-    "jquery": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
-      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==",
-      "dev": true
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3677,16 +3642,16 @@
         }
       }
     },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "map-obj": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
       "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
-      "dev": true
-    },
-    "marked": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
       "dev": true
     },
     "meow": {
@@ -4977,6 +4942,24 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "spawn-wrap": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
@@ -5648,6 +5631,27 @@
       "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
       "dev": true
     },
+    "ts-node": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
+      "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        }
+      }
+    },
     "tslib": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
@@ -5690,6 +5694,51 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedoc": {
+      "version": "0.17.7",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.7.tgz",
+      "integrity": "sha512-PEnzjwQAGjb0O8a6VDE0lxyLAadqNujN5LltsTUhZETolRMiIJv6Ox+Toa8h0XhKHqAOh8MOmB0eBVcWz6nuAw==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^8.1.0",
+        "handlebars": "^4.7.6",
+        "highlight.js": "^10.0.0",
+        "lodash": "^4.17.15",
+        "lunr": "^2.3.8",
+        "marked": "1.0.0",
+        "minimatch": "^3.0.0",
+        "progress": "^2.0.3",
+        "shelljs": "^0.8.4",
+        "typedoc-default-themes": "^0.10.1"
+      },
+      "dependencies": {
+        "marked": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
+          "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==",
+          "dev": true
+        }
+      }
+    },
+    "typedoc-default-themes": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.10.1.tgz",
+      "integrity": "sha512-SuqAQI0CkwhqSJ2kaVTgl37cWs733uy9UGUqwtcds8pkFK8oRF4rZmCq+FXTGIb9hIUOu40rf5Kojg0Ha6akeg==",
+      "dev": true,
+      "requires": {
+        "lunr": "^2.3.8"
+      }
+    },
+    "typedoc-plugin-markdown": {
+      "version": "2.2.17",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-2.2.17.tgz",
+      "integrity": "sha512-eE6cTeqsZIbjur6RG91Lhx1vTwjR49OHwVPRlmsxY3dthS4FNRL8sHxT5Y9pkosBwv1kSmNGQEPHjMYy1Ag6DQ==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^8.1.0",
+        "handlebars": "^4.7.3"
+      }
+    },
     "typescript": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",
@@ -5705,12 +5754,6 @@
       "requires": {
         "commander": "~2.20.3"
       }
-    },
-    "underscore": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
-      "dev": true
     },
     "uniq": {
       "version": "1.0.1",
@@ -5993,6 +6036,12 @@
         "lodash": "^4.17.15",
         "yargs": "^13.3.0"
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,11 +9,12 @@
     "prelint": "npm run build",
     "lint": "standardx src examples",
     "fix": "standardx --fix",
-    "pretest": "npm run lint",
+    "pretest": "npm run lint && npm run test:ts",
     "test": "mocha test/**/*.js",
+    "test:ts": "mocha --require ts-node/register ./test-ts/**/*.ts",
     "coverage": "nyc --reporter=lcov --reporter=text npm run test",
     "coverage-publish": "wget -qO - https://coverage.codacy.com/get.sh | bash -s report -l JavaScript -r coverage/lcov.info",
-    "generate-docs": "typedoc --tsconfig ./tsconfig.json src",
+    "generate-docs": "typedoc --tsconfig ./tsconfig.json --plugin typedoc-plugin-markdown src",
     "release": "standard-version",
     "prepublish": "npm run build"
   },
@@ -101,9 +102,10 @@
     "uuid": "~8.0.0"
   },
   "devDependencies": {
-    "@paztis/typedoc": "^0.1.6",
     "@types/ajv": "^1.0.0",
     "@types/axios": "^0.14.0",
+    "@types/chai": "^4.2.11",
+    "@types/mocha": "^7.0.2",
     "@types/node": "^13.13.9",
     "chai": "~4.2.0",
     "eslint-config-standard": "^14.1.1",
@@ -114,6 +116,9 @@
     "nyc": "~15.0.0",
     "standard-version": "^7.1.0",
     "standardx": "^5.0.0",
+    "ts-node": "^8.10.2",
+    "typedoc": "^0.17.7",
+    "typedoc-plugin-markdown": "^2.2.17",
     "typescript": "^3.8.3"
   },
   "publishConfig": {

--- a/src/lib/bindings/http/http_emitter.ts
+++ b/src/lib/bindings/http/http_emitter.ts
@@ -1,4 +1,4 @@
-import { CloudEvent } from "../../cloudevent.js";
+import { CloudEvent } from "../../cloudevent";
 
 const BinaryHTTPEmitter = require("./emitter_binary.js");
 const StructuredEmitter = require("./emitter_structured.js");
@@ -20,7 +20,7 @@ const {
  * @see https://github.com/cloudevents/spec/blob/v1.0/http-protocol-binding.md#13-content-modes
  */
 export class HTTPEmitter {
-  url: URL | undefined;
+  url: URL | string;
   binary: any;
   structured: any;
   static headers: Function;
@@ -34,7 +34,7 @@ export class HTTPEmitter {
    * @param {string} [options.version] The HTTP binding specification version. Default: "1.0"
    * @throws {TypeError} if no options.url is provided or an unknown specification version is provided.
    */
-  constructor({ url, version = SPEC_V1 } = { url: undefined }) {
+  constructor({ url = "", version = SPEC_V1 }) {
     if (version !== SPEC_V03 && version !== SPEC_V1) {
       throw new TypeError(
         `Unknown CloudEvent specification version: ${version}`);
@@ -62,7 +62,7 @@ export class HTTPEmitter {
    * Possible values are "binary" and "structured". Default: structured
    * @returns {Promise} Promise with an eventual response from the receiver
    */
-  send(event: CloudEvent, { url, mode = "binary", ...httpOpts } = { url: undefined }) {
+  send(event: CloudEvent, { url = "", mode = "binary", ...httpOpts } = {}) {
     // @ts-ignore Type 'URL | undefined' is not assignable to type 'undefined'. Type 'URL' is not assignable to type 'undefined'.ts(2322)
     if (!url) { url = this.url; }
     // @ts-ignore Property 'url' does not exist on type '{}'
@@ -85,7 +85,7 @@ export class HTTPEmitter {
  * @param {string} [version] spec version number - default 1.0
  * @returns {Object} the headers that will be sent for the event
  */
-function headers(event: CloudEvent, version = SPEC_V1) {
+function headers(event: CloudEvent, version: string = SPEC_V1) {
   const headers = {};
   let headerMap;
   if (version === SPEC_V1) {

--- a/src/lib/bindings/http/http_receiver.ts
+++ b/src/lib/bindings/http/http_receiver.ts
@@ -44,7 +44,7 @@ export class HTTPReceiver {
    * @param {Object|JSON} body The body of the HTTP request
    * @return {CloudEvent} A new {CloudEvent} instance
    */
-  accept(headers: {}, body: { specversion: string }) {
+  accept(headers: {}, body: { specversion?: string, [k:string]: any }) {
     const mode: string = getMode(headers);
     const version = getVersion(mode, headers, body);
     switch (version) {
@@ -70,7 +70,7 @@ function getMode(headers: { [key: string]: string }) {
   throw new ValidationError("no cloud event detected");
 }
 
-function getVersion(mode: string, headers: { [key: string]: string }, body: string | { specversion: string }) {
+function getVersion(mode: string, headers: { [key: string]: string }, body: string | { specversion?: string }) {
   if (mode === BINARY) {
     // Check the headers for the version
     const versionHeader = headers[DEFAULT_SPEC_VERSION_HEADER];

--- a/src/lib/cloudevent.ts
+++ b/src/lib/cloudevent.ts
@@ -81,7 +81,7 @@ export class CloudEvent {
       this.time = event.time;
     }
     this.formatter = new Formatter();
-    this.extensions = [];
+    this.extensions = {};
   }
 
   /**

--- a/test-ts/cloud_event_test.ts
+++ b/test-ts/cloud_event_test.ts
@@ -1,18 +1,45 @@
-const { CloudEvent } = require("../");
-const { SPEC_V1, SPEC_V03 } = require("../lib/bindings/http/constants.js");
+import { expect } from "chai";
+import { CloudEvent } from "../";
+import { CloudEventV03Attributes } from "../lib/v03";
+import { CloudEventV1Attributes } from "../lib/v1";
 
-const { expect } = require("chai");
+const { SPEC_V1, SPEC_V03 } = require("../lib/bindings/http/constants");
 
-const fixture = {
-  source: "http://unit.test",
-  type: "org.cncf.cloudevents.example"
+interface Message {
+  type: string;
+  subject: string;
+  data: any;
+  source: string;
+  dataContentType: string;
+}
+
+const type = "org.cncf.cloudevents.example";
+const source = "http://unit.test";
+
+const message: Message = {
+  type,
+  source,
+  subject: "greeting",
+  data: {
+      hello: "world"
+  },
+  dataContentType: "application/json"
 };
 
-describe("A 1.0 CloudEvent", () => {
-  it("must be created with a source and type", () => {
-    expect(() => new CloudEvent()).to.throw(TypeError, "event type and source are required");
-  });
+const fixture: CloudEventV1Attributes|CloudEventV03Attributes = {
+  source,
+  type
+};
 
+describe("A CloudEvent", () => {
+  it("Can be constructed with a typed Message", () => {
+    const ce = new CloudEvent(message);
+    expect(ce.type).to.equal(type);
+    expect(ce.source).to.equal(source);
+  });
+});
+
+describe("A 1.0 CloudEvent", () => {
   it("has retreivable source and type attributes", () => {
     const ce = new CloudEvent(fixture);
     expect(ce.source).to.equal("http://unit.test");
@@ -86,9 +113,10 @@ describe("A 1.0 CloudEvent", () => {
     expect(ce.data).to.equal(data);
   });
 
-  it("has extensions as an empty array by default", () => {
+  it("has extensions as an empty object by default", () => {
     const ce = new CloudEvent(fixture);
-    expect(ce.extensions).to.be.an('array').that.has.a.lengthOf(0);
+    expect(ce.extensions).to.be.an('object')
+    expect(Object.keys(ce.extensions).length).to.equal(0);
   });
 
   it("throws ValidationError if the CloudEvent does not conform to the schema");
@@ -98,13 +126,7 @@ describe("A 1.0 CloudEvent", () => {
 
 
 describe("A 0.3 CloudEvent", () => {
-
-  const specversion = { specversion: SPEC_V03 };
-  const v03fixture = { ...specversion, ...fixture };
-
-  it("must be created with a source and type", () => {
-    expect(() => new CloudEvent(specversion)).to.throw(TypeError, "event type and source are required");
-  });
+  const v03fixture: CloudEventV03Attributes = { specversion: SPEC_V03, ...fixture };
 
   it("has retreivable source and type attributes", () => {
     const ce = new CloudEvent(v03fixture);

--- a/test-ts/http_emitter_test.ts
+++ b/test-ts/http_emitter_test.ts
@@ -1,5 +1,6 @@
-const { expect } = require("chai");
-const nock = require("nock");
+import "mocha";
+import { expect } from "chai";
+import nock from "nock";
 
 const {
   SPEC_V1,
@@ -7,17 +8,17 @@ const {
   DEFAULT_CE_CONTENT_TYPE,
   BINARY_HEADERS_03,
   BINARY_HEADERS_1
-} = require("../../../lib/bindings/http/constants.js");
+} = require("../lib/bindings/http/constants");
 
-const { CloudEvent, HTTPEmitter } = require("../../../");
+import { CloudEvent, HTTPEmitter } from "..";
 
-const receiver = "https://cloudevents.io/";
-const type = "com.example.test";
-const source = "urn:event:from:myapi/resource/123";
-const ext1Name = "lunch";
-const ext1Value = "tacos";
-const ext2Name = "supper";
-const ext2Value = "sushi";
+const receiver:string = "https://cloudevents.io/";
+const type:string = "com.example.test";
+const source:string = "urn:event:from:myapi/resource/123";
+const ext1Name:string = "lunch";
+const ext1Value:string = "tacos";
+const ext2Name:string = "supper";
+const ext2Value:string = "sushi";
 
 const data = {
   lunchBreak: "noon"
@@ -27,7 +28,7 @@ describe("HTTP Transport Binding Emitter for CloudEvents", () => {
   beforeEach(() => {
     nock(receiver)
       .post("/")
-      .reply(function(uri, requestBody) {
+      .reply(function (uri, requestBody: {}) {
         // return the request body and the headers so they can be
         // examined in the test
         if (typeof requestBody === "string") {
@@ -54,7 +55,7 @@ describe("HTTP Transport Binding Emitter for CloudEvents", () => {
     event.addExtension(ext2Name, ext2Value);
 
     it("Sends a binary 1.0 CloudEvent by default", () => {
-      emitter.send(event).then((response) => {
+      emitter.send(event).then((response: { data: { [k: string]: string } }) => {
           // A binary message will have a ce-id header
           expect(response.data[BINARY_HEADERS_1.ID]).to.equal(event.id);
           expect(response.data[BINARY_HEADERS_1.SPEC_VERSION]).to.equal(SPEC_V1);
@@ -74,7 +75,7 @@ describe("HTTP Transport Binding Emitter for CloudEvents", () => {
 
     it("Sends a structured 1.0 CloudEvent if specified", () => {
       emitter.send(event, { mode: "structured" })
-        .then((response) => {
+        .then((response: { data: { [k: string]: string | {}, data: { lunchBreak: string } } }) => {
           // A structured message will have a cloud event content type
           expect(response.data["content-type"]).to.equal(DEFAULT_CE_CONTENT_TYPE);
           // Ensure other CE headers don't exist - just testing for ID
@@ -88,7 +89,7 @@ describe("HTTP Transport Binding Emitter for CloudEvents", () => {
     it("Sends to an alternate URL if specified", () => {
       nock(receiver)
         .post("/alternate")
-        .reply(function(uri, requestBody) {
+        .reply(function (uri, requestBody: {}) {
           // return the request body and the headers so they can be
           // examined in the test
           if (typeof requestBody === "string") {
@@ -102,7 +103,7 @@ describe("HTTP Transport Binding Emitter for CloudEvents", () => {
         });
 
       emitter.send(event, { mode: "structured", url: `${receiver}alternate` })
-        .then((response) => {
+        .then((response: { [k: string]: string | {}, data: { [k: string]: string | {}, specversion: string, data: { lunchBreak: string }} }) => {
           // A structured message will have a cloud event content type
           expect(response.data["content-type"]).to.equal(DEFAULT_CE_CONTENT_TYPE);
           // Ensure other CE headers don't exist - just testing for ID
@@ -127,7 +128,7 @@ describe("HTTP Transport Binding Emitter for CloudEvents", () => {
     event.addExtension(ext2Name, ext2Value);
 
     it("Sends a binary 0.3 CloudEvent", () => {
-      emitter.send(event).then((response) => {
+      emitter.send(event).then((response: { data: { lunchBreak: string, [k:string]: string }}) => {
         // A binary message will have a ce-id header
         expect(response.data[BINARY_HEADERS_03.ID]).to.equal(event.id);
         expect(response.data[BINARY_HEADERS_03.SPEC_VERSION]).to.equal(SPEC_V03);
@@ -146,8 +147,8 @@ describe("HTTP Transport Binding Emitter for CloudEvents", () => {
     });
 
     it("Sends a structured 0.3 CloudEvent if specified", () => {
-      emitter.send(event, { mode: "structured", foo: "bar" })
-        .then((response) => {
+      emitter.send(event, { mode: "structured" })
+        .then((response: { data: { [k:string]: any, specversion: string, data: { lunchBreak: string } }}) => {
           // A structured message will have a cloud event content type
           expect(response.data["content-type"]).to.equal(DEFAULT_CE_CONTENT_TYPE);
           // Ensure other CE headers don't exist - just testing for ID
@@ -161,7 +162,7 @@ describe("HTTP Transport Binding Emitter for CloudEvents", () => {
     it("Sends to an alternate URL if specified", () => {
       nock(receiver)
         .post("/alternate")
-        .reply(function(uri, requestBody) {
+        .reply(function (uri, requestBody: {}) {
           // return the request body and the headers so they can be
           // examined in the test
           if (typeof requestBody === "string") {
@@ -175,7 +176,7 @@ describe("HTTP Transport Binding Emitter for CloudEvents", () => {
         });
 
       emitter.send(event, { mode: "structured", url: `${receiver}alternate` })
-        .then((response) => {
+        .then((response: { data: { specversion: string, data: { lunchBreak: string }, [k:string]: any }}) => {
           // A structured message will have a cloud event content type
           expect(response.data["content-type"]).to.equal(DEFAULT_CE_CONTENT_TYPE);
           // Ensure other CE headers don't exist - just testing for ID

--- a/test-ts/http_receiver_test.ts
+++ b/test-ts/http_receiver_test.ts
@@ -1,5 +1,7 @@
-const { expect } = require("chai");
-const { CloudEvent, HTTPReceiver } = require("../../../index.js");
+import "mocha";
+import { expect } from "chai";
+import { CloudEvent, HTTPReceiver } from "..";
+import { CloudEventV1 } from "../lib/v1";
 const {
   HEADER_CONTENT_TYPE,
   DEFAULT_CONTENT_TYPE,
@@ -7,8 +9,8 @@ const {
   DEFAULT_SPEC_VERSION_HEADER,
   BINARY_HEADERS_03,
   BINARY_HEADERS_1
-} = require("../../../lib/bindings/http/constants.js");
-const ValidationError = require("../../../lib/bindings/http/validation/validation_error.js");
+} = require("../lib/bindings/http/constants");
+const ValidationError = require("../lib/bindings/http/validation/validation_error.js");
 
 const receiver = new HTTPReceiver();
 const id = "1234";
@@ -140,7 +142,7 @@ describe("HTTP Transport Binding Receiver for CloudEvents", () => {
   });
 });
 
-function validateEvent(event, specversion) {
+function validateEvent(event: CloudEventV1, specversion: string) {
   expect(event instanceof CloudEvent).to.equal(true);
   expect(event.id).to.equal(id);
   expect(event.type).to.equal(type);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,9 +16,11 @@
   "include": [
     "src/**/*.ts"
   ],
-  "exclude": [],
+  "exclude": [
+    "node_modules"
+  ],
   "typedocOptions": {
     "out": "docs",
-    "mode": "library"
+    "mode": "file"
   }
 }


### PR DESCRIPTION
This commit modifies the existing TypeScript files with improved
(read: functional) typings for function parameters. This became an
issue when trying to use the module in an existing TypeScript module.

Tests for the TypeScript files have been moved to a new test folder
specifically for testing TypeScript usage via ts-node.

Signed-off-by: Lance Ball <lball@redhat.com>