### PR TITLE
Update examples to latest(2.x) sdk

### DIFF
--- a/examples/express-ex/index.js
+++ b/examples/express-ex/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 const express = require("express");
-const { HTTPReceiver } = require("../../src");
+const { HTTPReceiver } = require("cloudevents-sdk");
 
 const app = express();
 const receiver = new HTTPReceiver();

--- a/examples/express-ex/package.json
+++ b/examples/express-ex/package.json
@@ -14,7 +14,7 @@
   "author": "fabiojose@gmail.com",
   "license": "Apache-2.0",
   "dependencies": {
-    "cloudevents-sdk": "~1.0.0",
+    "cloudevents-sdk": "~2.0.2",
     "express": "^4.17.1"
   }
 }

--- a/examples/typescript-ex/README.md
+++ b/examples/typescript-ex/README.md
@@ -15,5 +15,3 @@ Then, start
 ```bash
 npm start
 ```
-
-See your event payload [here, at requestbin](https://requestbin.com/r/enu90y24i64jp)

--- a/examples/typescript-ex/package.json
+++ b/examples/typescript-ex/package.json
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "keywords": [],
   "scripts": {
-    "start": "node build/src/index.js",
+    "start": "node build/index.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "check": "gts check",
     "clean": "gts clean",
@@ -22,9 +22,9 @@
     "posttest": "npm run check"
   },
   "devDependencies": {
-    "gts": "^1.1.0",
-    "typescript": "~3.5.0",
     "@types/node": "^8.9.0",
-    "cloudevents-sdk": "1.0.0"
+    "cloudevents-sdk": "~2.0.2",
+    "gts": "^1.1.0",
+    "typescript": "~3.9.5"
   }
 }

--- a/examples/typescript-ex/prettier.config.js
+++ b/examples/typescript-ex/prettier.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  singleQuote: true,
-  trailingComma: "es5"
-};

--- a/examples/typescript-ex/src/index.ts
+++ b/examples/typescript-ex/src/index.ts
@@ -1,45 +1,49 @@
-import { CloudEvent, HTTPREceiver } from '../../';
+import { CloudEvent, HTTPReceiver } from "cloudevents-sdk";
+import { CloudEventV1 } from "cloudevents-sdk/lib/v1";
 
 export function doSomeStuff() {
-  const receiver = new HTTPREceiver();
+  const receiver = new HTTPReceiver();
 
-  const myevent: CloudEvent = new CloudEvent()
-    .source('/source')
-    .type('type')
-    .dataContentType('text/plain')
-    .dataschema('http://d.schema.com/my.json')
-    .subject('cha.json')
-    .data('my-data')
-    .addExtension("my-ext", "0x600");
+  const myevent: CloudEventV1 = new CloudEvent({
+    source: "/source",
+    type: "type",
+    dataContentType: "text/plain",
+    dataSchema: "https://d.schema.com/my.json",
+    subject: "cha.json",
+    data: "my-data"
+  });
+  myevent.addExtension("extension-1", "some extension data");
 
-  console.log(myevent.toString());
-  console.log(myevent.getExtensions());
+  console.log("My structured event:", myevent.toString());
+  console.log("My structured event extensions:", myevent.getExtensions());
 
   // ------ receiver structured
-  const payload = myevent.toString();
+  // The header names should be standarized to use lowercase
   const headers = {
-    "Content-Type":"application/cloudevents+json"
+    "content-type": "application/cloudevents+json"
   };
 
-  console.log(receiver.accept(headers, payload).toString());
+  // Typically used with an incoming HTTP request where myevent.format() is the actual
+  // body of the HTTP
+  console.log("Received structured event:", receiver.accept(headers, myevent.format()).toString());
 
   // ------ receiver binary
-  const extension1 = "mycuston-ext1";
   const data = {
-    "data" : "dataString"
+    "data": "dataString"
   };
   const attributes = {
-    "ce-type"        : "type",
-    "ce-specversion" : "1.0",
-    "ce-source"      : "source",
-    "ce-id"          : "id",
-    "ce-time"        : "2019-06-16T11:42:00Z",
-    "ce-dataschema"  : "http://schema.registry/v1",
-    "Content-Type"   : "application/json",
-    "ce-extension1"  : extension1
+    "ce-type": "type",
+    "ce-specversion": "1.0",
+    "ce-source": "source",
+    "ce-id": "id",
+    "ce-time": "2019-06-16T11:42:00Z",
+    "ce-dataschema": "http://schema.registry/v1",
+    "Content-Type": "application/json",
+    "ce-extension1": "extension1"
   };
 
-  console.log(receiver.accept(attributes, data).toString());
+  console.log("My binary event:", receiver.accept(attributes, data).toString());
+  console.log("My binary event extensions:", receiver.accept(attributes, data).toString());
 
   return true;
 }

--- a/examples/typescript-ex/tsconfig.json
+++ b/examples/typescript-ex/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "build",
+    "rootDir": "./src",
+    "outDir": "./build/",
     "lib": [
       "es6",
       "dom"


### PR DESCRIPTION
This PR starts to update the examples in `examples` to use the latest released cloudevents-sdk(which is 2.x atm)

fixes #187 