### PR TITLE
feat: pass extension into the constructor.

### DIFF
--- a/src/lib/cloudevent.ts
+++ b/src/lib/cloudevent.ts
@@ -5,6 +5,7 @@ import Spec1 from "./bindings/http/v1/spec_1.js";
 import Spec03 from "./bindings/http/v03/spec_0_3.js";
 import Formatter from "./formats/json/formatter.js";
 import { isBinary } from "./bindings/http/validation/fun.js";
+import Extensions from "./extensions";
 
 const { SPEC_V1, SPEC_V03 } = require("./bindings/http/constants");
 
@@ -18,7 +19,7 @@ export type CE = CloudEventV1 | CloudEventV1Attributes | CloudEventV03 | CloudEv
 export class CloudEvent {
   spec: any;
   formatter: any;
-  extensions: object;
+  extensions: Extensions;
 
   /**
    * Creates a new CloudEvent instance

--- a/src/lib/cloudevent.ts
+++ b/src/lib/cloudevent.ts
@@ -18,7 +18,7 @@ export type CE = CloudEventV1 | CloudEventV1Attributes | CloudEventV03 | CloudEv
 export class CloudEvent {
   spec: any;
   formatter: any;
-  extensions: {};
+  extensions: object;
 
   /**
    * Creates a new CloudEvent instance
@@ -33,6 +33,7 @@ export class CloudEvent {
    * @param {string} [event.schemaURL]  The URI of the schema that the event data adheres to (v0.3 events)
    * @param {string} [event.dataContentEncoding] The content encoding for the event data (v0.3 events)
    * @param {string} [event.specversion] The CloudEvent specification version for this event - default: 1.0
+   * @param {object} [event.extensions] The CloudEvent extensions for this event
    * @param {*} [event.data] The event payload
    */
   constructor(event: CE) {
@@ -81,7 +82,13 @@ export class CloudEvent {
       this.time = event.time;
     }
     this.formatter = new Formatter();
+
     this.extensions = {};
+    if (event.extensions) {
+        for (const key in event.extensions) {
+            this.addExtension(key, event.extensions[key]);
+        }
+    }
   }
 
   /**

--- a/src/lib/extensions.ts
+++ b/src/lib/extensions.ts
@@ -1,0 +1,3 @@
+export default interface Extensions {
+  [key: string]: any
+}

--- a/src/lib/v03/index.ts
+++ b/src/lib/v03/index.ts
@@ -1,3 +1,5 @@
+import Extensions from "../extensions";
+
 /**
  * The object interface for CloudEvents 0.3.
  * @see https://github.com/cloudevents/spec/blob/v0.3/spec.md
@@ -130,6 +132,8 @@ export interface CloudEventV03Attributes {
   /**
    * [OPTIONAL] CloudEvents extension attributes.
    */
+  extensions?: Extensions;
+
   // tslint:disable-next-line:no-any
   [key: string]: any;
 }

--- a/src/lib/v1/index.ts
+++ b/src/lib/v1/index.ts
@@ -1,3 +1,4 @@
+import Extensions from "../extensions";
 /**
  * The object interface for CloudEvents 1.0.
  * @see https://github.com/cloudevents/spec/blob/v1.0/spec.md
@@ -124,6 +125,8 @@ export interface CloudEventV1Attributes {
   /**
    * [OPTIONAL] CloudEvents extension attributes.
    */
+  extensions?: Extensions;
+
   // tslint:disable-next-line:no-any
   [key: string]: any;
 }

--- a/test-ts/cloud_event_test.ts
+++ b/test-ts/cloud_event_test.ts
@@ -119,6 +119,16 @@ describe("A 1.0 CloudEvent", () => {
     expect(Object.keys(ce.extensions).length).to.equal(0);
   });
 
+  it("can be constructed with extensions", () => {
+    const extensions = {
+      "extension-key": "extension-value"
+    };
+    const ce = new CloudEvent({
+      extensions, ...fixture
+    });
+    expect(Object.keys(ce.extensions).length).to.equal(1);
+  });
+
   it("throws ValidationError if the CloudEvent does not conform to the schema");
   it("returns a JSON string even if format is invalid");
   it("correctly formats a CloudEvent as JSON");

--- a/test-ts/cloud_event_test.ts
+++ b/test-ts/cloud_event_test.ts
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import { CloudEvent } from "../";
 import { CloudEventV03Attributes } from "../lib/v03";
 import { CloudEventV1Attributes } from "../lib/v1";
+import Extensions from "../lib/extensions";
 
 const { SPEC_V1, SPEC_V03 } = require("../lib/bindings/http/constants");
 
@@ -120,13 +121,14 @@ describe("A 1.0 CloudEvent", () => {
   });
 
   it("can be constructed with extensions", () => {
-    const extensions = {
+    const extensions: Extensions = {
       "extension-key": "extension-value"
     };
     const ce = new CloudEvent({
       extensions, ...fixture
     });
     expect(Object.keys(ce.extensions).length).to.equal(1);
+    expect(ce.extensions["extension-key"]).to.equal(extensions["extension-key"]);
   });
 
   it("throws ValidationError if the CloudEvent does not conform to the schema");


### PR DESCRIPTION
* This allows someone to pass an extension/extensions into the CloudEvent contructor when creating a CloudEvent.

fixes #209

Signed-off-by: Lucas Holmquist <lholmqui@redhat.com>