### PR TITLE
fix: correct the spread order for http_emitter options

### DIFF
--- a/src/lib/bindings/http/emitter_binary.js
+++ b/src/lib/bindings/http/emitter_binary.js
@@ -53,7 +53,7 @@ class BinaryHTTPEmitter {
    * @returns {Promise} Promise with an eventual response from the receiver
    */
   async emit(options, cloudevent) {
-    const config = { ...options, ...defaults };
+    const config = { ...defaults, ...options };
     const headers = config[HEADERS];
 
     this.headerParserMap.forEach((parser, getterName) => {

--- a/test-ts/http_emitter_test.ts
+++ b/test-ts/http_emitter_test.ts
@@ -64,6 +64,17 @@ describe("HTTP Transport Binding Emitter for CloudEvents", () => {
       }).catch(expect.fail);
     });
 
+    it("Sends a binary CloudEvent with Custom Headers", () => {
+      emitter.send(event, { headers: { customheader: "value" } }).then((response: { data: { [k: string]: string } }) => {
+        // A binary message will have a ce-id header
+        expect(response.data.headers.customheader).to.equal("value");
+        expect(response.data[BINARY_HEADERS_1.ID]).to.equal(event.id);
+        expect(response.data[BINARY_HEADERS_1.SPEC_VERSION]).to.equal(SPEC_V1);
+        // A binary message will have a request body for the data
+        expect(response.data.lunchBreak).to.equal(data.lunchBreak);
+      }).catch(expect.fail);
+    });
+
     it("Provides the HTTP headers for a binary event", () => {
       const headers = HTTPEmitter.headers(event);
       expect(headers[BINARY_HEADERS_1.TYPE]).to.equal(event.type);


### PR DESCRIPTION
fixes: #223


I would like to add a test for this,  but I think some type definitions need to be added so typescript doesn't complain about me trying to pass in more options in the send method.  Keeping as Draft for now


Signed-off-by: Lucas Holmquist <lholmqui@redhat.com>