### PR TITLE
Validate a Cloud Event on creation and make it read only with a method to augment it

### DIFF
--- a/src/event/cloudevent.ts
+++ b/src/event/cloudevent.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
 
-import { CloudEventV1, validateV1, CloudEventV1Attributes } from "./v1";
-import { CloudEventV03, validateV03, CloudEventV03Attributes } from "./v03";
+import { CloudEventV1, validateV1, CloudEventV1Attributes, CloudEventV1OptionalAttributes } from "./v1";
+import { CloudEventV03, validateV03, CloudEventV03Attributes, CloudEventV03OptionalAttributes } from "./v03";
 import { ValidationError, isBinary, asBase64 } from "./validation";
 import CONSTANTS from "../constants";
 import { isString } from "util";
@@ -98,6 +98,10 @@ export class CloudEvent implements CloudEventV1, CloudEventV03 {
     for (const [key, value] of Object.entries(properties)) {
       this[key] = value;
     }
+
+    this.validate();
+
+    Object.freeze(this);
   }
 
   get time(): string | Date {
@@ -164,5 +168,23 @@ export class CloudEvent implements CloudEventV1, CloudEventV03 {
         throw new ValidationError("invalid payload", e);
       }
     }
+  }
+
+  /**
+   * Clone a CloudEvent with new/update attributes
+   * @param {object} options attributes to augment the CloudEvent with
+   * @throws if the CloudEvent does not conform to the schema
+   * @return {CloudEvent} returns a new CloudEvent
+   */
+  public cloneWith(
+    options:
+      | CloudEventV1
+      | CloudEventV1Attributes
+      | CloudEventV1OptionalAttributes
+      | CloudEventV03
+      | CloudEventV03Attributes
+      | CloudEventV03OptionalAttributes,
+  ): CloudEvent {
+    return new CloudEvent(Object.assign({}, this.toJSON(), options) as CloudEvent);
   }
 }

--- a/src/event/v03/cloudevent.ts
+++ b/src/event/v03/cloudevent.ts
@@ -25,7 +25,7 @@ export interface CloudEventV03 extends CloudEventV03Attributes {
   specversion: string;
 }
 
-export interface CloudEventV03Attributes {
+export interface CloudEventV03Attributes extends CloudEventV03OptionalAttributes {
   /**
    * [REQUIRED] Identifies the context in which an event happened. Often this
    * will include information such as the type of the event source, the
@@ -57,7 +57,9 @@ export interface CloudEventV03Attributes {
    * @example com.example.object.delete.v2
    */
   type: string;
+}
 
+export interface CloudEventV03OptionalAttributes {
   /**
    * The following fields are optional.
    */

--- a/src/event/v1/cloudevent.ts
+++ b/src/event/v1/cloudevent.ts
@@ -25,7 +25,7 @@ export interface CloudEventV1 extends CloudEventV1Attributes {
   specversion: string;
 }
 
-export interface CloudEventV1Attributes {
+export interface CloudEventV1Attributes extends CloudEventV1OptionalAttributes {
   /**
    * [REQUIRED] Identifies the context in which an event happened. Often this
    * will include information such as the type of the event source, the
@@ -58,7 +58,9 @@ export interface CloudEventV1Attributes {
    * @example com.example.object.delete.v2
    */
   type: string;
+}
 
+export interface CloudEventV1OptionalAttributes {
   /**
    * The following fields are optional.
    */

--- a/test/integration/cloud_event_test.ts
+++ b/test/integration/cloud_event_test.ts
@@ -139,7 +139,7 @@ describe("A 0.3 CloudEvent", () => {
   });
 
   it("can be constructed with a datacontentencoding", () => {
-    const ce = new CloudEvent({ datacontentencoding: "Base64", ...v03fixture });
+    const ce = new CloudEvent({ datacontentencoding: "Base64", ...v03fixture, data: "SSB3YXMgZnVubnkg8J+Ygg==" });
     expect(ce.datacontentencoding).to.equal("Base64");
   });
 

--- a/test/integration/http_binding_03.ts
+++ b/test/integration/http_binding_03.ts
@@ -38,9 +38,9 @@ const cloudevent = new CloudEvent({
   dataschema: "",
   datacontentencoding: "",
   data_base64: "",
+  [ext1Name]: ext1Value,
+  [ext2Name]: ext2Value,
 });
-cloudevent[ext1Name] = ext1Value;
-cloudevent[ext2Name] = ext2Value;
 
 const cebase64 = new CloudEvent({
   specversion: Version.V03,
@@ -51,9 +51,9 @@ const cebase64 = new CloudEvent({
   time,
   schemaurl,
   data: dataBase64,
+  [ext1Name]: ext1Value,
+  [ext2Name]: ext2Value,
 });
-cebase64[ext1Name] = ext1Value;
-cebase64[ext2Name] = ext2Value;
 
 const webhook = "https://cloudevents.io/webhook";
 const httpcfg = {

--- a/test/integration/http_binding_1.ts
+++ b/test/integration/http_binding_1.ts
@@ -25,7 +25,7 @@ const ext1Value = "foobar";
 const ext2Name = "extension2";
 const ext2Value = "acme";
 
-const cloudevent = new CloudEvent({
+let cloudevent = new CloudEvent({
   specversion: Version.V1,
   type,
   source,
@@ -35,8 +35,7 @@ const cloudevent = new CloudEvent({
   dataschema,
   data,
 });
-cloudevent[ext1Name] = ext1Value;
-cloudevent[ext2Name] = ext2Value;
+cloudevent = cloudevent.cloneWith({ [ext1Name]: ext1Value, [ext2Name]: ext2Value });
 
 const dataString = ")(*~^my data for ce#@#$%";
 
@@ -81,9 +80,9 @@ describe("HTTP Transport Binding - Version 1.0", () => {
             source,
             datacontenttype: "text/plain",
             data: bindata,
+            [ext1Name]: ext1Value,
+            [ext2Name]: ext2Value,
           });
-          binevent[ext1Name] = ext1Value;
-          binevent[ext2Name] = ext2Value;
 
           return emitStructured(binevent, httpcfg).then((response: AxiosResponse) => {
             expect(JSON.parse(response.config.data).data_base64).to.equal(expected);
@@ -96,9 +95,9 @@ describe("HTTP Transport Binding - Version 1.0", () => {
             source,
             datacontenttype: "text/plain",
             data: Uint32Array.from(dataString as string, (c) => c.codePointAt(0) as number),
+            [ext1Name]: ext1Value,
+            [ext2Name]: ext2Value,
           });
-          binevent[ext1Name] = ext1Value;
-          binevent[ext2Name] = ext2Value;
 
           return emitStructured(binevent, httpcfg).then((response: AxiosResponse) => {
             expect(JSON.parse(response.config.data)).to.have.property("data_base64");


### PR DESCRIPTION
- [x] Validate the Cloud Event in the Constructor
- [x] Freeze the Object that is created
- [x] Update/Add extensions after the fact
- [x] Modify other properties if needed
- [x] Update Tests
 

During the creation of a CloudEvent,  the validate method is now called.  The object is also frozen to make it read-only.

A new method `cloneWith` has been added which can be used to add/update attributes such as extensions and will return a new Cloud Event Object

fixes #233 


related #29 

Signed-off-by: Lucas Holmquist <lholmqui@redhat.com>