### PR TITLE
chore(actions): don't auto-close stale issues and pull requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,5 +15,5 @@ jobs:
         days-before-stale: 30
         days-before-close: 0
         stale-pr-message: 'This pull request is stale because it has been open 30 days with no activity.'
-        stale-issue-label: 'no-issue-activity'
-        stale-pr-label: 'no-pr-activity'
+        stale-issue-label: 'status/no-issue-activity'
+        stale-pr-label: 'status/no-pr-activity'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open 30 days with no activity.'
         days-before-stale: 30
-        days-before-close: 0
+        days-before-close: -1
         stale-pr-message: 'This pull request is stale because it has been open 30 days with no activity.'
         stale-issue-label: 'status/no-issue-activity'
         stale-pr-label: 'status/no-pr-activity'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,21 +1,19 @@
-name: Mark stale issues and pull requests
+name: Issue Triage
 
 on:
   schedule:
   - cron: "0 0 * * *"
 
 jobs:
-  stale:
-
+  triage_issues:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/stale@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days'
+        stale-issue-message: 'This issue is stale because it has been open 30 days with no activity.'
         days-before-stale: 30
-        days-before-close: 5
-        stale-pr-message: 'This pull request is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days'
+        days-before-close: 0
+        stale-pr-message: 'This pull request is stale because it has been open 30 days with no activity.'
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'


### PR DESCRIPTION
Open issues and pull requests should be closed by a human who has considered
the issue/pr and made a choice based on the content of the issue/pr and the
state of the repository.

What this means in practice is that some issues will stay open for a long
time, even if they are stale. They may be open because it really is something
that will be considered for future work. Periodic issue triage should be
done by the maintainers, and if an issue _should_ be closed - for example,
the issue is no longer relevant - then a maintainer can close it.

Signed-off-by: Lance Ball <lball@redhat.com>