### PR TITLE
fix: ensure that the HTTP receiver sanitizes headers in accept()

### DIFF
--- a/src/transport/receiver.ts
+++ b/src/transport/receiver.ts
@@ -1,4 +1,4 @@
-import { Headers } from "./http/headers";
+import { Headers, sanitize } from "./http/headers";
 import { CloudEvent, Version, ValidationError } from "..";
 import { BinaryHTTPReceiver as BinaryReceiver } from "./http/binary_receiver";
 import { StructuredHTTPReceiver as StructuredReceiver } from "./http/structured_receiver";
@@ -60,16 +60,17 @@ export class Receiver {
    * @return {CloudEvent} A new {CloudEvent} instance
    */
   accept(headers: Headers, body: string | Record<string, unknown> | CloudEventV1 | CloudEventV03): CloudEvent {
-    const mode: Mode = getMode(headers);
-    const version = getVersion(mode, headers, body);
+    const cleanHeaders: Headers = sanitize(headers);
+    const mode: Mode = getMode(cleanHeaders);
+    const version = getVersion(mode, cleanHeaders, body);
     switch (version) {
       case Version.V1:
-        return this.receivers.v1[mode].parse(body, headers);
+        return this.receivers.v1[mode].parse(body, cleanHeaders);
       case Version.V03:
-        return this.receivers.v03[mode].parse(body, headers);
+        return this.receivers.v03[mode].parse(body, cleanHeaders);
       default:
         console.error(`Unknown spec version ${version}. Default to ${Version.V1}`);
-        return this.receivers.v1[mode].parse(body, headers);
+        return this.receivers.v1[mode].parse(body, cleanHeaders);
     }
   }
 }

--- a/src/transport/receiver.ts
+++ b/src/transport/receiver.ts
@@ -65,12 +65,12 @@ export class Receiver {
     const version = getVersion(mode, cleanHeaders, body);
     switch (version) {
       case Version.V1:
-        return this.receivers.v1[mode].parse(body, cleanHeaders);
+        return this.receivers.v1[mode].parse(body, headers);
       case Version.V03:
-        return this.receivers.v03[mode].parse(body, cleanHeaders);
+        return this.receivers.v03[mode].parse(body, headers);
       default:
         console.error(`Unknown spec version ${version}. Default to ${Version.V1}`);
-        return this.receivers.v1[mode].parse(body, cleanHeaders);
+        return this.receivers.v1[mode].parse(body, headers);
     }
   }
 }

--- a/test/http_receiver_test.ts
+++ b/test/http_receiver_test.ts
@@ -52,6 +52,35 @@ describe("HTTP Transport Binding Receiver for CloudEvents", () => {
       expect(typeof event.data).to.equal("object");
       expect((event.data as Record<string, string>).lunch).to.equal("sushi");
     });
+
+    it("Recognizes headers in title case for binary events", () => {
+      const binaryHeaders = {
+        "Content-Type": "application/json; charset=utf-8",
+        "ce-specversion": specversion,
+        "ce-id": id,
+        "ce-type": type,
+        "ce-source": source,
+      };
+
+      const event: CloudEvent = receiver.accept(binaryHeaders, data);
+      expect(event.validate()).to.be.true;
+      expect((event.data as Record<string, string>).lunch).to.equal("sushi");
+    });
+
+    it("Recognizes headers in title case for structured events", () => {
+      const structuredHeaders = { "Content-Type": "application/cloudevents+json" };
+      const payload = {
+        id,
+        type,
+        source,
+        data,
+        specversion,
+      };
+
+      const event: CloudEvent = receiver.accept(structuredHeaders, payload);
+      expect(event.validate()).to.be.true;
+      expect((event.data as Record<string, string>).lunch).to.equal("sushi");
+    });
   });
 
   describe("V1", () => {


### PR DESCRIPTION
Even though the underlying structured and binary receivers already sanitize
the headers, this needs to be done at the receiver.accept() level since
the headers are inspected there to determine what mode the event is being
sent as.

Fixes: https://github.com/cloudevents/sdk-javascript/issues/237

Signed-off-by: Lance Ball <lball@redhat.com>