### PR TITLE
chore: bump GH stale action to v3

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ jobs:
   triage_issues:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v1
+    - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open 30 days with no activity.'


### PR DESCRIPTION
This is the first version that actually avoids closing stale issues if `days-before-close < 0`.

Signed-off-by: Lance Ball <lball@redhat.com>