### PR TITLE
chore: add vscode task JSON and GitHub issue/pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,24 @@
+---
+name: Bug Report
+about: Create a report to help us improve this module
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the Bug**
+A clear and concise description of what the bug is.
+
+**Steps to Reproduce**
+1.
+2.
+3.
+
+**Expected Behavior**
+A clear and concise description of what you expected to happen.
+
+
+
+**Additional context**
+Add any other context about the problem here. If applicable, add screenshots to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,17 @@
+---
+name: Feature Request
+about: Suggest an idea for this module
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you would like to see**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,0 +1,15 @@
+<!-- General PR guidelines:
+
+Most PRs should be opened against the master branch.
+
+ -->
+
+## Proposed Changes
+
+- 
+-
+-
+
+## Description
+- Fixes Issue #
+- Version:

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,37 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "build",
+			"group": "build",
+			"problemMatcher": [],
+			"label": "npm: build",
+			"detail": "tsc --project tsconfig.json && tsc --project tsconfig.browser.json && webpack"
+		},
+		{
+			"type": "npm",
+			"script": "watch",
+			"group": "build",
+			"problemMatcher": [],
+			"label": "npm: watch",
+			"detail": "tsc --project tsconfig.json --watch"
+		},
+		{
+			"type": "npm",
+			"script": "lint",
+			"group": "build",
+			"problemMatcher": [],
+			"label": "npm: lint",
+			"detail": "eslint 'src/**/*.{js,ts}' 'test/**/*.{js,ts}'"
+		},
+		{
+			"type": "npm",
+			"script": "test",
+			"group": "test",
+			"problemMatcher": [],
+			"label": "npm: test",
+			"detail": "mocha --require ts-node/register ./test/integration/**/*.ts"
+		},
+	]
+}


### PR DESCRIPTION
This commit adds templates for GitHub issues and PRs, and a configuration
file for VSCode to enable build and test tasks in the IDE.

Signed-off-by: Lance Ball <lball@redhat.com>