### PR TITLE
lib: change Receiver#accept() to be static Receiver.accept

### DIFF
--- a/src/transport/receiver.ts
+++ b/src/transport/receiver.ts
@@ -4,7 +4,6 @@ import { BinaryHTTPReceiver as BinaryReceiver } from "./http/binary_receiver";
 import { StructuredHTTPReceiver as StructuredReceiver } from "./http/structured_receiver";
 import { CloudEventV03 } from "../event/v03";
 import { CloudEventV1 } from "../event/v1";
-import { Protocol } from "./protocols";
 import CONSTANTS from "../constants";
 
 /**
@@ -15,42 +14,21 @@ export enum Mode {
   STRUCTURED = "structured",
 }
 
+const receivers = {
+  v1: {
+    structured: new StructuredReceiver(Version.V1),
+    binary: new BinaryReceiver(Version.V1),
+  },
+  v03: {
+    structured: new StructuredReceiver(Version.V03),
+    binary: new BinaryReceiver(Version.V03),
+  },
+};
+
 /**
  * A class to receive a CloudEvent from an HTTP POST request.
  */
 export class Receiver {
-  protocol: Protocol;
-  receivers: {
-    v1: {
-      structured: StructuredReceiver;
-      binary: BinaryReceiver;
-      [key: string]: unknown;
-    };
-    v03: {
-      structured: StructuredReceiver;
-      binary: BinaryReceiver;
-      [key: string]: unknown;
-    };
-  };
-
-  /**
-   * Create an instance of an HTTPReceiver to accept incoming CloudEvents.
-   * @param {Protocol} protocol the transport protocol - currently only Protocol.HTTP is supported
-   */
-  constructor(protocol: Protocol = Protocol.HTTP) {
-    // currently unused, but reserved for future protocol implementations
-    this.protocol = protocol;
-    this.receivers = {
-      v1: {
-        structured: new StructuredReceiver(Version.V1),
-        binary: new BinaryReceiver(Version.V1),
-      },
-      v03: {
-        structured: new StructuredReceiver(Version.V03),
-        binary: new BinaryReceiver(Version.V03),
-      },
-    };
-  }
   /**
    * Acceptor for an incoming HTTP CloudEvent POST. Can process
    * binary and structured incoming CloudEvents.
@@ -59,7 +37,7 @@ export class Receiver {
    * @param {Object|JSON} body The body of the HTTP request
    * @return {CloudEvent} A new {CloudEvent} instance
    */
-  accept(
+  static accept(
     headers: Headers,
     body: string | Record<string, unknown> | CloudEventV1 | CloudEventV03 | undefined | null,
   ): CloudEvent {
@@ -68,12 +46,12 @@ export class Receiver {
     const version = getVersion(mode, cleanHeaders, body);
     switch (version) {
       case Version.V1:
-        return this.receivers.v1[mode].parse(body, headers);
+        return receivers.v1[mode].parse(body, headers);
       case Version.V03:
-        return this.receivers.v03[mode].parse(body, headers);
+        return receivers.v03[mode].parse(body, headers);
       default:
         console.error(`Unknown spec version ${version}. Default to ${Version.V1}`);
-        return this.receivers.v1[mode].parse(body, headers);
+        return receivers.v1[mode].parse(body, headers);
     }
   }
 }

--- a/test/conformance/steps.ts
+++ b/test/conformance/steps.ts
@@ -8,7 +8,6 @@ import { Receiver } from "../../src";
 const { HTTPParser } = require("http-parser-js");
 
 const parser = new HTTPParser(HTTPParser.REQUEST);
-const receiver = new Receiver();
 
 Given("HTTP Protocol Binding is supported", function (this: World) {
   return true;
@@ -28,7 +27,7 @@ Given("an HTTP request", function (request: string) {
 });
 
 When("parsed as HTTP request", function () {
-  this.cloudevent = receiver.accept(this.headers, this.body);
+  this.cloudevent = Receiver.accept(this.headers, this.body);
   return true;
 });
 

--- a/test/integration/http_receiver_test.ts
+++ b/test/integration/http_receiver_test.ts
@@ -3,7 +3,6 @@ import { expect } from "chai";
 import { CloudEvent, Receiver, ValidationError } from "../../src";
 import { CloudEventV1 } from "../../src/event/v1";
 
-const receiver = new Receiver();
 const id = "1234";
 const type = "org.cncf.cloudevents.test";
 const source = "urn:event:from:myapi/resourse/123";
@@ -22,7 +21,7 @@ describe("HTTP Transport Binding Receiver for CloudEvents", () => {
         specversion,
       };
 
-      expect(receiver.accept.bind(receiver, {}, payload)).to.throw(ValidationError, "no cloud event detected");
+      expect(Receiver.accept.bind(Receiver, {}, payload)).to.throw(ValidationError, "no cloud event detected");
     });
 
     it("Converts the JSON body of a binary event to an Object", () => {
@@ -34,7 +33,7 @@ describe("HTTP Transport Binding Receiver for CloudEvents", () => {
         "ce-source": source,
       };
 
-      const event: CloudEvent = receiver.accept(binaryHeaders, data);
+      const event: CloudEvent = Receiver.accept(binaryHeaders, data);
       expect(typeof event.data).to.equal("object");
       expect((event.data as Record<string, string>).lunch).to.equal("sushi");
     });
@@ -47,7 +46,7 @@ describe("HTTP Transport Binding Receiver for CloudEvents", () => {
         "ce-type": type,
         "ce-source": source,
       };
-      const event = receiver.accept(binaryHeaders, undefined);
+      const event = Receiver.accept(binaryHeaders, undefined);
       expect(event.data).to.be.undefined;
     });
 
@@ -59,7 +58,7 @@ describe("HTTP Transport Binding Receiver for CloudEvents", () => {
         "ce-type": type,
         "ce-source": source,
       };
-      const event = receiver.accept(binaryHeaders, null);
+      const event = Receiver.accept(binaryHeaders, null);
       expect(event.data).to.be.undefined;
     });
 
@@ -72,7 +71,7 @@ describe("HTTP Transport Binding Receiver for CloudEvents", () => {
         specversion,
       };
 
-      const event = receiver.accept(structuredHeaders, payload);
+      const event = Receiver.accept(structuredHeaders, payload);
       expect(typeof event.data).to.equal("object");
       expect((event.data as Record<string, string>).lunch).to.equal("sushi");
     });
@@ -86,7 +85,7 @@ describe("HTTP Transport Binding Receiver for CloudEvents", () => {
         "ce-source": source,
       };
 
-      const event: CloudEvent = receiver.accept(binaryHeaders, data);
+      const event: CloudEvent = Receiver.accept(binaryHeaders, data);
       expect(event.validate()).to.be.true;
       expect((event.data as Record<string, string>).lunch).to.equal("sushi");
     });
@@ -101,7 +100,7 @@ describe("HTTP Transport Binding Receiver for CloudEvents", () => {
         specversion,
       };
 
-      const event: CloudEvent = receiver.accept(structuredHeaders, payload);
+      const event: CloudEvent = Receiver.accept(structuredHeaders, payload);
       expect(event.validate()).to.be.true;
       expect((event.data as Record<string, string>).lunch).to.equal("sushi");
     });
@@ -119,7 +118,7 @@ describe("HTTP Transport Binding Receiver for CloudEvents", () => {
         specversion,
       };
 
-      const event = receiver.accept(structuredHeaders, payload);
+      const event = Receiver.accept(structuredHeaders, payload);
       validateEvent(event, specversion);
     });
 
@@ -132,7 +131,7 @@ describe("HTTP Transport Binding Receiver for CloudEvents", () => {
         "ce-source": source,
       };
 
-      const event = receiver.accept(binaryHeaders, data);
+      const event = Receiver.accept(binaryHeaders, data);
       validateEvent(event, specversion);
     });
   });
@@ -149,7 +148,7 @@ describe("HTTP Transport Binding Receiver for CloudEvents", () => {
         specversion,
       };
 
-      const event = receiver.accept(structuredHeaders, payload);
+      const event = Receiver.accept(structuredHeaders, payload);
       validateEvent(event, specversion);
     });
 
@@ -162,7 +161,7 @@ describe("HTTP Transport Binding Receiver for CloudEvents", () => {
         "ce-source": source,
       };
 
-      const event = receiver.accept(binaryHeaders, data);
+      const event = Receiver.accept(binaryHeaders, data);
       validateEvent(event, specversion);
     });
   });
@@ -192,7 +191,7 @@ describe("HTTP Transport Binding Receiver for CloudEvents", () => {
         "x-forwarded-proto": "http",
         "x-request-id": "d3649c1b-a968-40bf-a9da-3e853abc0c8b",
       };
-      const event = receiver.accept(headers, data);
+      const event = Receiver.accept(headers, data);
       expect(event instanceof CloudEvent).to.equal(true);
       expect(event.id).to.equal(id);
       expect(event.type).to.equal(type);


### PR DESCRIPTION
Note that I did not add a third `Protocol` parameter to `Receiver.accept` since
that would not currently be used. It's non-breaking to add a third parameter
in the future once additional protocols are supported.

Fixes: https://github.com/cloudevents/sdk-javascript/issues/266
Fixes: https://github.com/cloudevents/sdk-javascript/issues/261

BREAKING CHANGE