### PR TITLE
fix: ensure that event data can be an array, number, boolean or null

### DIFF
--- a/src/event/schemas.ts
+++ b/src/event/schemas.ts
@@ -10,7 +10,7 @@ export const schemaV1 = {
       type: "string",
     },
     data: {
-      type: ["object", "string"],
+      type: ["object", "string", "array", "number"],
     },
     data_base64: {
       type: "string",
@@ -89,7 +89,7 @@ export const schemaV03 = {
       type: "string",
     },
     data: {
-      type: ["object", "string"],
+      type: ["object", "string", "array", "number"],
     },
     event: {
       properties: {

--- a/src/event/schemas.ts
+++ b/src/event/schemas.ts
@@ -10,7 +10,7 @@ export const schemaV1 = {
       type: "string",
     },
     data: {
-      type: ["object", "string", "array", "number"],
+      type: ["object", "string", "array", "number", "boolean", "null"],
     },
     data_base64: {
       type: "string",
@@ -89,7 +89,7 @@ export const schemaV03 = {
       type: "string",
     },
     data: {
-      type: ["object", "string", "array", "number"],
+      type: ["object", "string", "array", "number", "boolean", "null"],
     },
     event: {
       properties: {

--- a/test/integration/cloud_event_test.ts
+++ b/test/integration/cloud_event_test.ts
@@ -117,6 +117,22 @@ describe("A 1.0 CloudEvent", () => {
     expect(ce.data).to.equal(100);
   });
 
+  it("can be constructed with null data", () => {
+    const ce = new CloudEvent({
+      ...fixture,
+      data: null,
+    });
+    expect(ce.data).to.equal(null);
+  });
+
+  it("can be constructed with data as a boolean", () => {
+    const ce = new CloudEvent({
+      ...fixture,
+      data: true,
+    });
+    expect(ce.data).to.be.true;
+  });
+
   it("can be constructed with extensions", () => {
     const extensions = {
       extensionkey: "extension-value",

--- a/test/integration/cloud_event_test.ts
+++ b/test/integration/cloud_event_test.ts
@@ -101,6 +101,22 @@ describe("A 1.0 CloudEvent", () => {
     expect(ce.data).to.deep.equal({ lunch: "tacos" });
   });
 
+  it("can be constructed with data as an Array", () => {
+    const ce = new CloudEvent({
+      ...fixture,
+      data: [{ lunch: "tacos" }, { supper: "sushi" }],
+    });
+    expect(ce.data).to.deep.equal([{ lunch: "tacos" }, { supper: "sushi" }]);
+  });
+
+  it("can be constructed with data as a number", () => {
+    const ce = new CloudEvent({
+      ...fixture,
+      data: 100,
+    });
+    expect(ce.data).to.equal(100);
+  });
+
   it("can be constructed with extensions", () => {
     const extensions = {
       extensionkey: "extension-value",


### PR DESCRIPTION
## Proposed Changes

The schema incorrectly limits data values to only object and string. This is
incorrect, since JSON can be an array, boolean, null or a single number as well.
This changes the schemas for both 0.3 and 1.0 events and adds test cases.

## Description
- Fixes: https://github.com/cloudevents/sdk-javascript/issues/280
- Version: 3.0.0


Signed-off-by: Lance Ball <lball@redhat.com>
