### PR TITLE
chore: Update examples to use latest sdk changes

### DIFF
--- a/examples/express-ex/README.md
+++ b/examples/express-ex/README.md
@@ -67,7 +67,7 @@ curl -X POST \
      -H'ce-source:https://github.com/cloudevents/spec/pull/123' \
      -H'ce-id:45c83279-c8a1-4db6-a703-b3768db93887' \
      -H'ce-time:2019-11-06T11:17:00Z' \
-     -H'ce-my-extension:extension value' \
+     -H'ce-myextension:extension value' \
      http://localhost:3000/
 ```
 
@@ -110,6 +110,17 @@ curl -X POST \
      http://localhost:3000/
 ```
 
+__A Structured One with Base64 Event Data__
+
+> Payload [example](../payload/v03/structured-event-2.json)
+
+```bash
+curl -X POST \
+     -d'@../payload/v03/structured-event-2.json' \
+     -H'Content-Type:application/cloudevents+json' \
+     http://localhost:3000/
+```
+
 __A Binary One__
 
 ```bash
@@ -135,7 +146,7 @@ curl -X POST \
      -H'ce-source:https://github.com/cloudevents/spec/pull/123' \
      -H'ce-id:45c83279-c8a1-4db6-a703-b3768db93887' \
      -H'ce-time:2019-06-21T17:31:00Z' \
-     -H'ce-my-extension:extension value' \
+     -H'ce-myextension:extension value' \
      http://localhost:3000/
 ```
 

--- a/examples/express-ex/index.js
+++ b/examples/express-ex/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 const express = require("express");
-const { Receiver } = require("cloudevents-sdk");
+const { Receiver } = require("cloudevents");
 
 const app = express();
 const receiver = new Receiver();
@@ -25,7 +25,7 @@ app.post("/", function (req, res) {
   console.log("BODY", req.body);
 
   try {
-    const event = receiver.accept(req.headers, req.body);
+    const event = Receiver.accept(req.headers, req.body);
     console.log(`Accepted event: ${event}`);
     res.status(201).json(event);
   } catch (err) {

--- a/examples/express-ex/package.json
+++ b/examples/express-ex/package.json
@@ -14,7 +14,7 @@
   "author": "fabiojose@gmail.com",
   "license": "Apache-2.0",
   "dependencies": {
-    "cloudevents-sdk": "~2.0.2",
+    "cloudevents": "~3.0.0",
     "express": "^4.17.1"
   }
 }

--- a/examples/payload/v03/structured-event-1.json
+++ b/examples/payload/v03/structured-event-1.json
@@ -8,7 +8,7 @@
   "data":{
     "much":"wow"
   },
-  "my-extension" : {
+  "myextension" : {
     "some" : "thing"
   }
 }

--- a/examples/payload/v03/structured-event-2.json
+++ b/examples/payload/v03/structured-event-2.json
@@ -7,7 +7,7 @@
   "datacontenttype":"application/json",
   "datacontentencoding":"base64",
   "data":"eyJtdWNoIjoid293In0=",
-  "my-extension" : {
+  "myextension" : {
     "some" : "thing"
   }
 }

--- a/examples/payload/v1/structured-event-1.json
+++ b/examples/payload/v1/structured-event-1.json
@@ -8,5 +8,5 @@
   "data":{
     "much":"wow"
   },
-  "my-extension" : "something"
+  "myextension" : "something"
 }

--- a/examples/payload/v1/structured-event-2.json
+++ b/examples/payload/v1/structured-event-2.json
@@ -6,5 +6,5 @@
   "time":"2019-11-06T11:08:00Z",
   "datacontenttype":"application/json",
   "data_base64":"eyJtdWNoIjoid293In0=",
-  "my-extension" : "something"
+  "myextension" : "something"
 }

--- a/examples/typescript-ex/package.json
+++ b/examples/typescript-ex/package.json
@@ -24,8 +24,10 @@
   },
   "devDependencies": {
     "@types/node": "^8.9.0",
-    "cloudevents-sdk": "~2.0.2",
     "gts": "^1.1.0",
     "typescript": "~3.9.5"
+  },
+  "dependencies": {
+    "cloudevents": "~3.0.1"
   }
 }

--- a/examples/typescript-ex/src/index.ts
+++ b/examples/typescript-ex/src/index.ts
@@ -1,8 +1,6 @@
-import { CloudEvent, CloudEventV1, Receiver } from "cloudevents-sdk";
+import { CloudEvent, CloudEventV1, Receiver } from "cloudevents";
 
-export function doSomeStuff() {
-  const receiver = new Receiver();
-
+export function doSomeStuff(): void {
   const myevent: CloudEventV1 = new CloudEvent({
     source: "/source",
     type: "type",
@@ -10,8 +8,8 @@ export function doSomeStuff() {
     dataschema: "https://d.schema.com/my.json",
     subject: "cha.json",
     data: "my-data",
+    extension1: "some extension data"
   });
-  myevent.extension1 = "some extension data";
 
   console.log("My structured event:", myevent);
 
@@ -23,7 +21,7 @@ export function doSomeStuff() {
 
   // Typically used with an incoming HTTP request where myevent.format() is the actual
   // body of the HTTP
-  console.log("Received structured event:", receiver.accept(headers, myevent));
+  console.log("Received structured event:", Receiver.accept(headers, myevent));
 
   // ------ receiver binary
   const data = {
@@ -40,10 +38,9 @@ export function doSomeStuff() {
     "ce-extension1": "extension1",
   };
 
-  console.log("My binary event:", receiver.accept(attributes, data));
-  console.log("My binary event extensions:", receiver.accept(attributes, data));
+  console.log("My binary event:", Receiver.accept(attributes, data));
+  console.log("My binary event extensions:", Receiver.accept(attributes, data));
 
-  return true;
 }
 
 doSomeStuff();

--- a/examples/websocket/README.md
+++ b/examples/websocket/README.md
@@ -24,7 +24,7 @@ responds with a CloudEvent containing the body of the Weather API response as th
 event data.
 
 You will need to change one line in the `server.js` file and provide your Open
-Weather API key.
+Weather API key.  You can also create a environment variable `OPEN_WEATHER_API_KEY` and store your key there.
 
 To start the server, run `node server.js`.
 

--- a/examples/websocket/client.js
+++ b/examples/websocket/client.js
@@ -3,7 +3,7 @@ const readline = require("readline");
 const WebSocket = require("ws");
 const ws = new WebSocket("ws://localhost:8080");
 
-const { CloudEvent } = require("cloudevents-sdk");
+const { CloudEvent } = require("cloudevents");
 
 const rl = readline.createInterface({
   input: process.stdin,

--- a/examples/websocket/index.html
+++ b/examples/websocket/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>CloudEvent Example</title>
-    <script src="../../_bundles/cloudevents-sdk.js"></script>
+    <script src="../../bundles/cloudevents-sdk.js"></script>
     <script>
       const CloudEvent = window['cloudevents-sdk'].CloudEvent;
       const Version = window['cloudevents-sdk'].Version;

--- a/examples/websocket/package.json
+++ b/examples/websocket/package.json
@@ -15,7 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "cloudevents-sdk": "^2.0.2",
+    "cloudevents": "~3.0.1",
     "got": "^11.3.0",
     "ws": "^7.3.0"
   }

--- a/examples/websocket/server.js
+++ b/examples/websocket/server.js
@@ -1,12 +1,12 @@
 /* eslint-disable no-console */
 const got = require("got");
 
-const { CloudEvent } = require("cloudevents-sdk");
+const { CloudEvent } = require("cloudevents");
 const WebSocket = require("ws");
 const wss = new WebSocket.Server({ port: 8080 });
 
 const api = "https://api.openweathermap.org/data/2.5/weather";
-const key = "REPLACE WITH API KEY";
+const key = process.env.OPEN_WEATHER_API_KEY || "REPLACE WITH API KEY";
 
 console.log("WebSocket server started. Waiting for events.");
 
@@ -18,7 +18,7 @@ wss.on("connection", function connection(ws) {
     fetch(event.data.zip)
       .then((weather) => {
         const response = new CloudEvent({
-          dataContentType: "application/json",
+          datacontenttype: "application/json",
           type: "current.weather",
           source: "/weather.server",
           data: weather,


### PR DESCRIPTION
Signed-off-by: Lucas Holmquist <lholmqui@redhat.com>

## Proposed Changes

- This PR updates the examples to use the latest cloudevents module(3.x)

All the examples work except one curl statement in the express example that is being addressed by #284 and since we are using the `~` those changes will get picked up once a new patch version is released, automatically

## Description
- Fixes Issue #249 
- Version:
