### PR TITLE
fix: ensure that data encoded as base64 is parsed as an object

### DIFF
--- a/src/transport/http/binary_receiver.ts
+++ b/src/transport/http/binary_receiver.ts
@@ -84,9 +84,6 @@ export class BinaryHTTPReceiver {
       eventObj.datacontenttype === CONSTANTS.MIME_JSON &&
       eventObj.datacontentencoding === CONSTANTS.ENCODING_BASE64
     ) {
-      process.stdout.write(JSON.stringify(eventObj));
-      process.stdout.write(JSON.stringify(parsedPayload));
-
       delete eventObj.datacontentencoding;
     }
 

--- a/src/transport/http/binary_receiver.ts
+++ b/src/transport/http/binary_receiver.ts
@@ -77,6 +77,18 @@ export class BinaryHTTPReceiver {
         eventObj[header.substring(CONSTANTS.EXTENSIONS_PREFIX.length)] = headers[header];
       }
     }
+    // At this point, if the datacontenttype is application/json and the datacontentencoding is base64
+    // then the data has already been decoded as a string, then parsed as JSON. We don't need to have
+    // the datacontentencoding property set - in fact, it's incorrect to do so.
+    if (
+      eventObj.datacontenttype === CONSTANTS.MIME_JSON &&
+      eventObj.datacontentencoding === CONSTANTS.ENCODING_BASE64
+    ) {
+      process.stdout.write(JSON.stringify(eventObj));
+      process.stdout.write(JSON.stringify(parsedPayload));
+
+      delete eventObj.datacontentencoding;
+    }
 
     const cloudevent = new CloudEvent({ ...eventObj, data: parsedPayload } as CloudEventV1 | CloudEventV03);
     this.version === Version.V1 ? validateV1(cloudevent) : validateV03(cloudevent);

--- a/src/transport/http/structured_receiver.ts
+++ b/src/transport/http/structured_receiver.ts
@@ -1,6 +1,6 @@
 import { CloudEvent, Version } from "../..";
 import { Headers, sanitize } from "./headers";
-import { Parser, JSONParser, MappedParser } from "../../parsers";
+import { Parser, JSONParser, MappedParser, Base64Parser } from "../../parsers";
 import { parserByContentType } from "../../parsers";
 import { v1structuredParsers, v03structuredParsers } from "./versions";
 import { isString, isBase64, ValidationError, isStringOrObjectOrThrow } from "../../event/validation";
@@ -75,6 +75,10 @@ export class StructuredHTTPReceiver {
     if (eventObj.data && eventObj.datacontentencoding) {
       if (eventObj.datacontentencoding === CONSTANTS.ENCODING_BASE64 && !isBase64(eventObj.data)) {
         throw new ValidationError("invalid payload");
+      } else if (eventObj.datacontentencoding === CONSTANTS.ENCODING_BASE64) {
+        const dataParser = new Base64Parser();
+        eventObj.data = JSON.parse(dataParser.parse(eventObj.data as string));
+        delete eventObj.datacontentencoding;
       }
     }
 


### PR DESCRIPTION
## Proposed Changes

Parse incoming data as JSON for an event with `datacontentencoding` set to "base64"
and a content type of application/json or application/cloudevents+json.

## Description
The 0.3 specification states that `datacontentencoding` may be set to base64.
If an incoming event arrives over HTTP with this value set, and the content type
is either application/json or application/cloudevents+json, then we should ensure
that the data is decoded and parsed, and the `datacontentencoding` property is
removed.

- Fixes: https://github.com/cloudevents/sdk-javascript/issues/284
- See: https://github.com/cloudevents/sdk-javascript/pull/282
- Version: 3.0.0 (spec version 0.3)


Signed-off-by: Lance Ball <lball@redhat.com>
