### PR TITLE
chore(release): add postinstall script to warn users of name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # JavaScript SDK for CloudEvents
 
+## WARNING: This module has changed its name to 'cloudevents'.
+### PLEASE CONSIDER UPGRADING YOUR DEPENDENCY
+
+`npm install cloudevents`
+
+---
+
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/bd66e7c52002481993cd6d610534b0f7)](https://www.codacy.com/app/fabiojose/sdk-javascript?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=cloudevents/sdk-javascript&amp;utm_campaign=Badge_Grade)
 [![Codacy Badge](https://api.codacy.com/project/badge/Coverage/bd66e7c52002481993cd6d610534b0f7)](https://www.codacy.com/app/fabiojose/sdk-javascript?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=cloudevents/sdk-javascript&amp;utm_campaign=Badge_Coverage)
 ![Node.js CI](https://github.com/cloudevents/sdk-javascript/workflows/Node.js%20CI/badge.svg)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "coverage-publish": "wget -qO - https://coverage.codacy.com/get.sh | bash -s report -l JavaScript -r coverage/lcov.info",
     "generate-docs": "typedoc --tsconfig ./tsconfig.json --plugin typedoc-plugin-markdown src",
     "release": "standard-version",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "postinstall": "node ./postinstall/message.js"
   },
   "files": [
     "index.js",

--- a/postinstall/message.js
+++ b/postinstall/message.js
@@ -1,0 +1,10 @@
+// eslint-disable-next-line no-console
+console.log("\x1b[1m\x1b[31m%s\x1b[0m",`
+    >>>> Thank you for using cloudevents-sdk! <<<<
+
+    Note: As of version 3.0.0, this project has been renamed to 'cloudevents'.
+    To use the latest version of this module, please run:
+
+    npm install cloudevents
+
+`);


### PR DESCRIPTION
## Proposed Changes

Since we have recently changed the name of this module to 'cloudevents', users
may not be aware that version 2.0.2 is out of date, since it won't automatically
be upgraded on `npm install`.

## Description

This commit adds a postinstall script to warn users of this fact, and adds a
bold, top-level warning to the README.

- Fixes: https://github.com/cloudevents/sdk-javascript/issues/291
- Version: 2.x
Signed-off-by: Lance Ball <lball@redhat.com>

