### PR TITLE
lib(Constants): expose constants in a more intuitive way

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ import { Receiver, Mode } from "./transport/receiver";
 import { Protocol } from "./transport/protocols";
 import { Headers, headersFor } from "./transport/http/headers";
 
+import CONSTANTS from "./constants";
+
 export {
   // From event
   CloudEvent,
@@ -25,4 +27,6 @@ export {
   TransportOptions,
   Headers,
   headersFor,
+  // From Constants
+  CONSTANTS,
 };

--- a/test/integration/constants_test.ts
+++ b/test/integration/constants_test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import CONSTANTS from "../../src/constants";
+import { CONSTANTS } from "../../src";
 
 describe("Constants exposed by top level exports", () => {
   it("Exports an ENCODING_BASE64 constant", () => {


### PR DESCRIPTION
Signed-off-by: Lucas Holmquist <lholmqui@redhat.com>



## Proposed Changes

This change exposes the`Constants` from the "index" so a user no longer has to path into the dist folder.  I believe this was the original way to do it before the Typescript re-write


## Description
- Fixes Issue #298
- Version: 3.x
