### PR TITLE
fix: Add Correct Headers to emitted Binary Event

### DIFF
--- a/src/transport/http/binary_emitter.ts
+++ b/src/transport/http/binary_emitter.ts
@@ -20,7 +20,7 @@ export async function emitBinary(event: CloudEvent, options: TransportOptions): 
 }
 
 async function emit(event: CloudEvent, options: TransportOptions, headers: Headers): Promise<AxiosResponse> {
-  const contentType: Headers = { [CONSTANTS.HEADER_CONTENT_TYPE]: CONSTANTS.DEFAULT_CE_CONTENT_TYPE };
+  const contentType: Headers = { [CONSTANTS.HEADER_CONTENT_TYPE]: CONSTANTS.DEFAULT_CONTENT_TYPE };
   const config = {
     ...options,
     method: "POST",

--- a/test/integration/http_emitter_test.ts
+++ b/test/integration/http_emitter_test.ts
@@ -4,6 +4,7 @@ import nock from "nock";
 import CONSTANTS from "../../src/constants";
 
 const DEFAULT_CE_CONTENT_TYPE = CONSTANTS.DEFAULT_CE_CONTENT_TYPE;
+const DEFAULT_CONTENT_TYPE = CONSTANTS.DEFAULT_CONTENT_TYPE;
 
 import { CloudEvent, Version, Emitter, Protocol, headersFor } from "../../src";
 import { AxiosResponse } from "axios";
@@ -55,6 +56,7 @@ describe("HTTP Transport Binding Emitter for CloudEvents", () => {
         .send(event)
         .then((response: AxiosResponse) => {
           // A binary message will have a ce-id header
+          expect(response.data["content-type"]).to.equal(DEFAULT_CONTENT_TYPE);
           expect(response.data[CONSTANTS.CE_HEADERS.ID]).to.equal(event.id);
           expect(response.data[CONSTANTS.CE_HEADERS.SPEC_VERSION]).to.equal(Version.V1);
           // A binary message will have a request body for the data

--- a/test/integration/http_emitter_test.ts
+++ b/test/integration/http_emitter_test.ts
@@ -84,6 +84,7 @@ describe("HTTP Transport Binding Emitter for CloudEvents", () => {
         .then((response: { data: { [k: string]: string } }) => {
           // A binary message will have a ce-id header
           expect(response.data.customheader).to.equal("value");
+          expect(response.data["content-type"]).to.equal(DEFAULT_CONTENT_TYPE);
           expect(response.data[CONSTANTS.CE_HEADERS.ID]).to.equal(event.id);
           expect(response.data[CONSTANTS.CE_HEADERS.SPEC_VERSION]).to.equal(Version.V1);
           // A binary message will have a request body for the data


### PR DESCRIPTION
This changes the header of the emitted Binary Event to be the correct header


## Description
- Fixes Issue #301
- Version: 3.x
