### PR TITLE
chore: update the release script to signoff the commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "bundles"
   ],
   "standard-version": {
+    "scripts": {
+      "postcommit": "git commit --amend --signoff --no-edit"
+    },
     "types": [
       {
         "type": "feat",


### PR DESCRIPTION
This adds a postcommit hook to our release script to amend the commit with the signoff.

related to #304 

## Description
- Version:3.x
