### PR TITLE
docs: improve readme receiver example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ You can choose almost any popular web framework for port binding. Use an
 binary and structured events in either the 1.0 or 0.3 protocol formats.
 
 ```js
-const {
-  CloudEvent,
-  Receiver
-} = require("cloudevents");
+const app = require("express")();
+const {Receiver} = require("cloudevents");
 
-// body and headers come from an incoming HTTP request, e.g. express.js
-const receivedEvent = Receiver.accept(req.headers, req.body);
-console.log(receivedEvent);
+app.post("/", (req, res) => {
+  // body and headers come from an incoming HTTP request, e.g. express.js
+  const receivedEvent = Receiver.accept(req.headers, req.body);
+  console.log(receivedEvent);
+});
 ```
 
 #### Emitting Events

--- a/examples/express-ex/index.js
+++ b/examples/express-ex/index.js
@@ -1,10 +1,9 @@
 /* eslint-disable no-console */
 
 const express = require("express");
-const { Receiver } = require("cloudevents");
+const {Receiver} = require("cloudevents");
 
 const app = express();
-const receiver = new Receiver();
 
 app.use((req, res, next) => {
   let data = "";
@@ -20,7 +19,7 @@ app.use((req, res, next) => {
   });
 });
 
-app.post("/", function (req, res) {
+app.post("/", (req, res) => {
   console.log("HEADERS", req.headers);
   console.log("BODY", req.body);
 
@@ -34,6 +33,6 @@ app.post("/", function (req, res) {
   }
 });
 
-app.listen(3000, function () {
+app.listen(3000, () => {
   console.log("Example app listening on port 3000!");
 });


### PR DESCRIPTION
Improves the README examples for receiving CloudEvents.

## Proposed Changes

- Don't define unused imports
- Make `req` and `res` defined.
- Small JS syntax changes

Fixes: https://github.com/cloudevents/sdk-javascript/issues/308