### PR TITLE
test: implement pending tests leftover from TS rewrite

### DIFF
--- a/test/integration/cloud_event_test.ts
+++ b/test/integration/cloud_event_test.ts
@@ -144,9 +144,26 @@ describe("A 1.0 CloudEvent", () => {
     expect(ce["extensionkey"]).to.equal(extensions["extensionkey"]);
   });
 
-  it("throws ValidationError if the CloudEvent does not conform to the schema");
-  it("returns a JSON string even if format is invalid");
-  it("correctly formats a CloudEvent as JSON");
+  it("throws TypeError if the CloudEvent does not conform to the schema", () => {
+    try {
+      new CloudEvent({
+        ...fixture,
+        source: (null as unknown) as string,
+      });
+    } catch (err) {
+      expect(err).to.be.instanceOf(TypeError);
+      expect(err.message).to.equal("invalid payload");
+    }
+  });
+
+  it("correctly formats a CloudEvent as JSON", () => {
+    const ce = new CloudEvent({ ...fixture });
+    const json = ce.toString();
+    const obj = JSON.parse((json as unknown) as string);
+    expect(obj.type).to.equal(type);
+    expect(obj.source).to.equal(source);
+    expect(obj.specversion).to.equal(Version.V1);
+  });
 });
 
 describe("A 0.3 CloudEvent", () => {
@@ -211,7 +228,24 @@ describe("A 0.3 CloudEvent", () => {
     expect(ce.data).to.deep.equal({ lunch: "tacos" });
   });
 
-  it("throws ValidationError if the CloudEvent does not conform to the schema");
-  it("returns a JSON string even if format is invalid");
-  it("correctly formats a CloudEvent as JSON");
+  it("throws TypeError if the CloudEvent does not conform to the schema", () => {
+    try {
+      new CloudEvent({
+        ...v03fixture,
+        source: (null as unknown) as string,
+      });
+    } catch (err) {
+      expect(err).to.be.instanceOf(TypeError);
+      expect(err.message).to.equal("invalid payload");
+    }
+  });
+
+  it("correctly formats a CloudEvent as JSON", () => {
+    const ce = new CloudEvent({ ...v03fixture });
+    const json = ce.toString();
+    const obj = JSON.parse((json as unknown) as string);
+    expect(obj.type).to.equal(type);
+    expect(obj.source).to.equal(source);
+    expect(obj.specversion).to.equal(Version.V03);
+  });
 });


### PR DESCRIPTION

## Proposed Changes
- Implement pending `CloudEvent` tests

## Description
- Fixes Issue https://github.com/cloudevents/sdk-javascript/issues/232
- Version: 3.1.0

This commit implements 4 of the 6 pending tests that were not completed
during the TypeScript rewrite. The two tests that were not implemented
were (one for each of v1 and v03):

```
it("returns a JSON string even if format is invalid");
```

I don't really know what that's supposed to be/mean, so I removed them.


Signed-off-by: Lance Ball <lball@redhat.com>
