### PR TITLE
feat: add a constructor parameter for loose validation

### DIFF
--- a/src/event/validation.ts
+++ b/src/event/validation.ts
@@ -8,7 +8,18 @@ export class ValidationError extends TypeError {
   errors?: string[] | ErrorObject[] | null;
 
   constructor(message: string, errors?: string[] | ErrorObject[] | null) {
-    super(message);
+    const messageString =
+      errors instanceof Array
+        ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          errors?.reduce(
+            (accum: string, err: Record<string, string>) =>
+              (accum as string).concat(`
+  ${err instanceof Object ? JSON.stringify(err) : err}`),
+            message,
+          )
+        : message;
+    super(messageString);
     this.errors = errors ? errors : [];
   }
 }

--- a/test/integration/cloud_event_test.ts
+++ b/test/integration/cloud_event_test.ts
@@ -1,3 +1,4 @@
+import { ValidationError } from "ajv";
 import { expect } from "chai";
 import { CloudEvent, Version } from "../../src";
 import { CloudEventV03, CloudEventV1 } from "../../src/event/interfaces";
@@ -18,6 +19,22 @@ describe("A CloudEvent", () => {
     const ce = new CloudEvent(fixture);
     expect(ce.type).to.equal(type);
     expect(ce.source).to.equal(source);
+  });
+
+  it("Can be constructed with loose validation", () => {
+    const ce = new CloudEvent({} as CloudEventV1, false);
+    expect(ce).to.be.instanceOf(CloudEvent);
+  });
+
+  it("Loosely validated events can be cloned", () => {
+    const ce = new CloudEvent({} as CloudEventV1, false);
+    expect(ce.cloneWith({}, false)).to.be.instanceOf(CloudEvent);
+    console.error(ce);
+  });
+
+  it("Loosely validated events throw when validated", () => {
+    const ce = new CloudEvent({} as CloudEventV1, false);
+    expect(ce.validate).to.throw(TypeError, "invalid payload");
   });
 
   it("serializes as JSON with toString()", () => {

--- a/test/integration/cloud_event_test.ts
+++ b/test/integration/cloud_event_test.ts
@@ -1,6 +1,5 @@
-import { ValidationError } from "ajv";
 import { expect } from "chai";
-import { CloudEvent, Version } from "../../src";
+import { CloudEvent, ValidationError, Version } from "../../src";
 import { CloudEventV03, CloudEventV1 } from "../../src/event/interfaces";
 
 const type = "org.cncf.cloudevents.example";
@@ -12,6 +11,7 @@ const fixture: CloudEventV1 = {
   specversion: Version.V1,
   source,
   type,
+  data: `"some data"`,
 };
 
 describe("A CloudEvent", () => {
@@ -29,12 +29,11 @@ describe("A CloudEvent", () => {
   it("Loosely validated events can be cloned", () => {
     const ce = new CloudEvent({} as CloudEventV1, false);
     expect(ce.cloneWith({}, false)).to.be.instanceOf(CloudEvent);
-    console.error(ce);
   });
 
   it("Loosely validated events throw when validated", () => {
     const ce = new CloudEvent({} as CloudEventV1, false);
-    expect(ce.validate).to.throw(TypeError, "invalid payload");
+    expect(ce.validate).to.throw(ValidationError, "invalid payload");
   });
 
   it("serializes as JSON with toString()", () => {
@@ -169,7 +168,7 @@ describe("A 1.0 CloudEvent", () => {
       });
     } catch (err) {
       expect(err).to.be.instanceOf(TypeError);
-      expect(err.message).to.equal("invalid payload");
+      expect(err.message).to.include("invalid payload");
     }
   });
 
@@ -252,8 +251,8 @@ describe("A 0.3 CloudEvent", () => {
         source: (null as unknown) as string,
       });
     } catch (err) {
-      expect(err).to.be.instanceOf(TypeError);
-      expect(err.message).to.equal("invalid payload");
+      expect(err).to.be.instanceOf(ValidationError);
+      expect(err.message).to.include("invalid payload");
     }
   });
 


### PR DESCRIPTION
## Proposed Changes

- add a second, optional, boolean parameter called `strict` to `CloudEvent` constructor, defaulting to `true`.
- add a second, optional, boolean parameter  called `strict` to `CloudEvent.cloneWith()` defaulting to `true`
- skip all validation steps if `strict` is false
- add tests for these changes 

## Description

This commit adds a second, optional boolean parameter to the `CloudEvent`
constructor. When `false` is provided, the event constructor will not
perform validation of the event properties, values and extension names.

As I am writing this, I wonder if it will be less error prone to default to `false`
and call the parameter `looseValidation`. 

- Fixes: https://github.com/cloudevents/sdk-javascript/issues/325
- Version: 3.1.0
