### PR TITLE
chore: add an automated GH action for releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,7 +7,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: bcoe/release-please-action@v1.6.3
+      - uses: GoogleCloudPlatform/release-please-action@v1.6.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: node

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,8 +7,9 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v1.6.3
+      - uses: GoogleCloudPlatform/release-please-action@v2.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: node
           package-name: cloudevents
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"docs","section":"Documentation","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false},{"type":"src","section":"Miscellaneous","hidden":false},{"type":"style","section":"Miscellaneous","hidden":false},{"type":"refactor","section":"Miscellaneous","hidden":false},{"type":"perf","section":"Performance","hidden":false},{"type":"test","section":"Tests","hidden":false}]'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,14 @@
+on:
+   push:
+     branches:
+       - main
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bcoe/release-please-action@v1.6.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: node
+          package-name: cloudevents


### PR DESCRIPTION
## Proposed Changes

This adds the release-please GH action to automate our release process


~~Creating as a Draft since the changelog creation is still missing the full list of types~~

Also need to update the current release document with this new change, which can come in another issue if this works good

I've added a PR for the changelog creation, https://github.com/googleapis/release-please/pull/538

update(9/8/2020):  The above PR has been merged into release-please,  now i just need to create the PR against the GH action

update 2 (9/8/2020):  PR for the GH Action, https://github.com/GoogleCloudPlatform/release-please-action/pull/64




## Description
- Fixes Issue #312 
- Version:
