### PR TITLE
docs: update README with maintainer names

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,12 @@ There you will find Express.js, TypeScript and Websocket examples.
   to determine which week will have the call.
 - Slack: #cloudeventssdk channel under
   [CNCF's Slack workspace](https://slack.cncf.io/).
+- Maintainers typically available on Slack
+  - Fabio José
+  - Grant Timmerman
+  - Lance Ball
+  - Lucas Holmquist
 - Email: https://lists.cncf.io/g/cncf-cloudevents-sdk
-- Contact for additional information: Fabio José (`@fabiojose` on slack).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -145,10 +145,9 @@ There you will find Express.js, TypeScript and Websocket examples.
 - Slack: #cloudeventssdk channel under
   [CNCF's Slack workspace](https://slack.cncf.io/).
 - Maintainers typically available on Slack
-  - Fabio José
-  - Grant Timmerman
   - Lance Ball
   - Lucas Holmquist
+  - Grant Timmerman
 - Email: https://lists.cncf.io/g/cncf-cloudevents-sdk
 
 ## Contributing


### PR DESCRIPTION
## Proposed Changes

This commit changes the README to include all currently active
contributors to and the originator of the repository.

Signed-off-by: Lance Ball <lball@redhat.com>