### PR TITLE
fix: extend Node.js IncomingHttpHeaders in our Headers type

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -48,6 +48,6 @@ const CONSTANTS = Object.freeze({
     DATA_SCHEMA: "dataschema",
     DATA_BASE64: "data_base64",
   },
-});
+} as const);
 
 export default CONSTANTS;

--- a/src/event/cloudevent.ts
+++ b/src/event/cloudevent.ts
@@ -175,7 +175,6 @@ export class CloudEvent implements CloudEventV1, CloudEventV03 {
     try {
       return validateCloudEvent(this);
     } catch (e) {
-      console.error(e.errors);
       if (e instanceof ValidationError) {
         throw e;
       } else {

--- a/src/message/http/index.ts
+++ b/src/message/http/index.ts
@@ -71,7 +71,7 @@ export function deserialize(message: Message): CloudEvent {
  * @returns {Mode} the transport mode
  */
 function getMode(headers: Headers): Mode {
-  const contentType = headers[CONSTANTS.HEADER_CONTENT_TYPE];
+  const contentType = headers[CONSTANTS.HEADER_CONTENT_TYPE] as string;
   if (contentType && contentType.startsWith(CONSTANTS.MIME_CE)) {
     return Mode.STRUCTURED;
   }
@@ -198,7 +198,7 @@ function parseStructured(message: Message, version: Version): CloudEvent {
   // Clone and low case all headers names
   const sanitizedHeaders = sanitize(headers);
 
-  const contentType = sanitizedHeaders[CONSTANTS.HEADER_CONTENT_TYPE];
+  const contentType = sanitizedHeaders[CONSTANTS.HEADER_CONTENT_TYPE] as string;
   const parser: Parser = contentType ? parserByContentType[contentType] : new JSONParser();
   if (!parser) throw new ValidationError(`invalid content type ${sanitizedHeaders[CONSTANTS.HEADER_CONTENT_TYPE]}`);
   const incoming = { ...(parser.parse(payload) as Record<string, unknown>) };

--- a/src/message/http/index.ts
+++ b/src/message/http/index.ts
@@ -71,7 +71,7 @@ export function deserialize(message: Message): CloudEvent {
  * @returns {Mode} the transport mode
  */
 function getMode(headers: Headers): Mode {
-  const contentType = headers[CONSTANTS.HEADER_CONTENT_TYPE] as string;
+  const contentType = headers[CONSTANTS.HEADER_CONTENT_TYPE];
   if (contentType && contentType.startsWith(CONSTANTS.MIME_CE)) {
     return Mode.STRUCTURED;
   }
@@ -198,7 +198,7 @@ function parseStructured(message: Message, version: Version): CloudEvent {
   // Clone and low case all headers names
   const sanitizedHeaders = sanitize(headers);
 
-  const contentType = sanitizedHeaders[CONSTANTS.HEADER_CONTENT_TYPE] as string;
+  const contentType = sanitizedHeaders[CONSTANTS.HEADER_CONTENT_TYPE];
   const parser: Parser = contentType ? parserByContentType[contentType] : new JSONParser();
   if (!parser) throw new ValidationError(`invalid content type ${sanitizedHeaders[CONSTANTS.HEADER_CONTENT_TYPE]}`);
   const incoming = { ...(parser.parse(payload) as Record<string, unknown>) };

--- a/src/message/index.ts
+++ b/src/message/index.ts
@@ -1,3 +1,4 @@
+import { IncomingHttpHeaders } from "http";
 import { CloudEvent } from "..";
 import { binary, deserialize, structured, isEvent } from "./http";
 import { headersFor } from "./http/headers";
@@ -18,8 +19,8 @@ export interface Binding {
  * Headers is an interface representing transport-agnostic headers as
  * key/value string pairs
  */
-export interface Headers {
-  [key: string]: string;
+export interface Headers extends IncomingHttpHeaders {
+  [key: string]: string | string[] | undefined;
 }
 
 /**

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -2,7 +2,7 @@ import CONSTANTS from "./constants";
 import { isString, isDefinedOrThrow, isStringOrObjectOrThrow, ValidationError } from "./event/validation";
 
 export abstract class Parser {
-  abstract parse(payload: Record<string, unknown> | string): unknown;
+  abstract parse(payload: Record<string, unknown> | string | string[] | undefined): unknown;
 }
 
 export class JSONParser implements Parser {

--- a/test/integration/emitter_factory_test.ts
+++ b/test/integration/emitter_factory_test.ts
@@ -48,7 +48,7 @@ function superagentEmitter(message: Message, options?: Options): Promise<unknown
   }
   // set headers
   for (const key of Object.getOwnPropertyNames(message.headers)) {
-    post.set(key, message.headers[key]);
+    post.set(key, message.headers[key] as string);
   }
   return post.send(message.body);
 }

--- a/test/integration/message_test.ts
+++ b/test/integration/message_test.ts
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import { IncomingHttpHeaders } from "http";
 import { CloudEvent, CONSTANTS, Version } from "../../src";
 import { asBase64 } from "../../src/event/validation";
 import { Message, HTTP } from "../../src/message";
@@ -83,6 +84,25 @@ describe("HTTP transport", () => {
     expect(() => {
       HTTP.structured(badEvent);
     }).to.throw;
+  });
+
+  it("Can be created with Node's IncomingHttpHeaders", () => {
+    const headers: IncomingHttpHeaders = {
+      "content-type": CONSTANTS.DEFAULT_CE_CONTENT_TYPE,
+    };
+    const body = JSON.stringify({
+      id,
+      type,
+      source,
+      specversion: Version.V1,
+      data: { lunch: "tacos" },
+    });
+    const message: Message = {
+      headers,
+      body,
+    };
+    const event = HTTP.toEvent(message);
+    expect(event.data).to.deep.equal({ lunch: "tacos" });
   });
 
   describe("Specification version V1", () => {


### PR DESCRIPTION
## Proposed Changes

- extend Node.js `IncomingHttpHeaders` in our `Headers` type

## Description

Changes the `Headers` type to make it more compatible with Node.js TypeScript projects.

- Fixes: https://github.com/cloudevents/sdk-javascript/issues/340
- Version:

Signed-off-by: Lance Ball <lball@redhat.com>
