### PR TITLE
src(receiver): don't default specversion on receiving if there isn't one.

### DIFF
--- a/src/message/http/index.ts
+++ b/src/message/http/index.ts
@@ -54,10 +54,9 @@ export function isEvent(message: Message): boolean {
 export function deserialize(message: Message): CloudEvent {
   const cleanHeaders: Headers = sanitize(message.headers);
   const mode: Mode = getMode(cleanHeaders);
-  let version = getVersion(mode, cleanHeaders, message.body);
+  const version = getVersion(mode, cleanHeaders, message.body);
   if (version !== Version.V03 && version !== Version.V1) {
-    console.error(`Unknown spec version ${version}. Default to ${Version.V1}`);
-    version = Version.V1;
+    throw new ValidationError(`Unknown spec version: ${version}`);
   }
   switch (mode) {
     case Mode.BINARY:
@@ -105,7 +104,7 @@ function getVersion(mode: Mode, headers: Headers, body: string | Record<string, 
     // structured mode - the version is in the body
     return typeof body === "string" ? JSON.parse(body).specversion : (body as CloudEvent).specversion;
   }
-  return Version.V1;
+  // return Version.V1;
 }
 
 /**

--- a/test/integration/http_receiver_test.ts
+++ b/test/integration/http_receiver_test.ts
@@ -24,6 +24,32 @@ describe("HTTP Transport Binding Receiver for CloudEvents", () => {
       expect(Receiver.accept.bind(Receiver, {}, payload)).to.throw(ValidationError, "no cloud event detected");
     });
 
+    it("Throws when the event does not have a valid spec version - Structured", () => {
+      const payload = {
+        id,
+        type,
+        source,
+        data,
+      };
+
+      expect(() => {
+        Receiver.accept(structuredHeaders, payload);
+      }).throw(ValidationError, "Unknown spec version: undefined");
+    });
+
+    it("Throws when the event does not have a valid spec version - Binary", () => {
+      const binaryHeaders = {
+        "content-type": "application/json; charset=utf-8",
+        "ce-id": id,
+        "ce-type": type,
+        "ce-source": source,
+      };
+
+      expect(() => {
+        Receiver.accept(binaryHeaders, data);
+      }).throw(ValidationError, "Unknown spec version: undefined");
+    });
+
     it("Converts the JSON body of a binary event to an Object", () => {
       const binaryHeaders = {
         "content-type": "application/json; charset=utf-8",


### PR DESCRIPTION
* When receiving an event,  we should not default the specversion to 1.0 if no specverion field is detected.
* If no specversion is detected or the specversion does not conform to a currently supported version, we will now throw a ValidationError

* This is a BREAKING_CHANGE

fixes #332, #333

Signed-off-by: Lucas Holmquist <lholmqui@redhat.com>

