### PR TITLE
chore(ci,releases): bump release-please-action to 2.5.5

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,7 +7,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v2.4.1
+      - uses: GoogleCloudPlatform/release-please-action@v2.5.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: node


### PR DESCRIPTION
## Proposed Changes

- Bump release-please-action to version 2.5.5

## Description

This should hopefully resolve the problem we are seeing with too many commits included in the changelog.

Signed-off-by: Lance Ball <lball@redhat.com>

