### PR TITLE
Emitter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,6 +30,7 @@
     }],
     "valid-jsdoc": "warn",
     "semi": ["error", "always"],
-    "quotes": ["error", "double", { "allowTemplateLiterals": true }]
+    "quotes": ["error", "double", { "allowTemplateLiterals": true }],
+    "@typescript-eslint/no-explicit-any": "off"
   }
 }

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ function sendWithAxios(message) {
 
 const emit = emitterFor(sendWithAxios, { mode: Mode.BINARY });
 // Set the emit
-Emitter.getSingleton().on("event", emit);
+Emitter.on("cloudevent", emit);
 
 ...
 // In any part of the code will send the event

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JavaScript SDK for CloudEvents
 
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/bd66e7c52002481993cd6d610534b0f7)](https://www.codacy.com/app/fabiojose/sdk-javascript?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=cloudevents/sdk-javascript&amp;utm_campaign=Badge_Grade)
-[![Codacy Badge](https://api.codacy.com/project/badge/Coverage/bd66e7c52002481993cd6d610534b0f7)](https://www.codacy.com/app/fabiojose/sdk-javascript?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=cloudevents/sdk-javascript&amp;utm_campaign=Badge_Coverage)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/bd66e7c52002481993cd6d610534b0f7)](https://www.codacy.com/app/fabiojose/sdk-javascript?utm_source=github.com&utm_medium=referral&utm_content=cloudevents/sdk-javascript&utm_campaign=Badge_Grade)
+[![Codacy Badge](https://api.codacy.com/project/badge/Coverage/bd66e7c52002481993cd6d610534b0f7)](https://www.codacy.com/app/fabiojose/sdk-javascript?utm_source=github.com&utm_medium=referral&utm_content=cloudevents/sdk-javascript&utm_campaign=Badge_Coverage)
 ![Node.js CI](https://github.com/cloudevents/sdk-javascript/workflows/Node.js%20CI/badge.svg)
 [![npm version](https://img.shields.io/npm/v/cloudevents.svg)](https://www.npmjs.com/package/cloudevents)
 [![vulnerabilities](https://snyk.io/test/github/cloudevents/sdk-javascript/badge.svg)](https://snyk.io/test/github/cloudevents/sdk-javascript)
@@ -10,9 +10,9 @@ The CloudEvents SDK for JavaScript.
 
 ## Features
 
-* Represent CloudEvents in memory
-* Serialize and deserialize CloudEvents in different [event formats](https://github.com/cloudevents/spec/blob/v1.0/spec.md#event-format).
-* Send and recieve CloudEvents with via different [protocol bindings](https://github.com/cloudevents/spec/blob/v1.0/spec.md#protocol-binding).
+- Represent CloudEvents in memory
+- Serialize and deserialize CloudEvents in different [event formats](https://github.com/cloudevents/spec/blob/v1.0/spec.md#event-format).
+- Send and recieve CloudEvents with via different [protocol bindings](https://github.com/cloudevents/spec/blob/v1.0/spec.md#protocol-binding).
 
 _Note:_ Supports CloudEvent versions 0.3, 1.0
 
@@ -51,16 +51,15 @@ using the `HTTP` binding to create a `Message` which has properties
 for `headers` and `body`.
 
 ```js
-const axios = require('axios').default;
+const axios = require("axios").default;
 const { HTTP } = require("cloudevents");
 
-
-const ce = new CloudEvent({ type, source, data })
+const ce = new CloudEvent({ type, source, data });
 const message = HTTP.binary(ce); // Or HTTP.structured(ce)
 
 axios({
-  method: 'post',
-  url: '...',
+  method: "post",
+  url: "...",
   data: message.body,
   headers: message.headers,
 });
@@ -69,7 +68,7 @@ axios({
 You may also use the `emitterFor()` function as a convenience.
 
 ```js
-const axios = require('axios').default;
+const axios = require("axios").default;
 const { emitterFor, Mode } = require("cloudevents");
 
 function sendWithAxios(message) {
@@ -77,8 +76,8 @@ function sendWithAxios(message) {
   // and body in this function, then send the
   // event
   axios({
-    method: 'post',
-    url: '...',
+    method: "post",
+    url: "...",
     data: message.body,
     headers: message.headers,
   });
@@ -88,9 +87,38 @@ const emit = emitterFor(sendWithAxios, { mode: Mode.BINARY });
 emit(new CloudEvent({ type, source, data }));
 ```
 
+You may also use the `Emitter` singleton
+
+```js
+const axios = require("axios").default;
+const { emitterFor, Mode, CloudEvent, Emitter } = require("cloudevents");
+
+function sendWithAxios(message) {
+  // Do what you need with the message headers
+  // and body in this function, then send the
+  // event
+  axios({
+    method: "post",
+    url: "...",
+    data: message.body,
+    headers: message.headers,
+  });
+}
+
+const emit = emitterFor(sendWithAxios, { mode: Mode.BINARY });
+// Set the emit
+Emitter.getSingleton().on("event", emit);
+
+...
+// In any part of the code will send the event
+new CloudEvent({ type, source, data }).emit();
+
+// You can also have several listener to send the event to several endpoint
+```
+
 ## CloudEvent Objects
 
-All created `CloudEvent` objects are read-only.  If you need to update a property or add a new extension to an existing cloud event object, you can use the `cloneWith` method.  This will return a new `CloudEvent` with any update or new properties.  For example:
+All created `CloudEvent` objects are read-only. If you need to update a property or add a new extension to an existing cloud event object, you can use the `cloneWith` method. This will return a new `CloudEvent` with any update or new properties. For example:
 
 ```js
 const {
@@ -112,24 +140,26 @@ There you will find Express.js, TypeScript and Websocket examples.
 
 ## Supported specification features
 
-| Core Specification |  [v0.3](https://github.com/cloudevents/spec/blob/v0.3/spec.md) | [v1.0](https://github.com/cloudevents/spec/blob/v1.0/spec.md) |
-| ----------------------------- | --- | --- |
-| CloudEvents Core              | :heavy_check_mark: | :heavy_check_mark: |
+| Core Specification | [v0.3](https://github.com/cloudevents/spec/blob/v0.3/spec.md) | [v1.0](https://github.com/cloudevents/spec/blob/v1.0/spec.md) |
+| ------------------ | ------------------------------------------------------------- | ------------------------------------------------------------- |
+| CloudEvents Core   | :heavy_check_mark:                                            | :heavy_check_mark:                                            |
+
 ---
 
-| Event Formats |  [v0.3](https://github.com/cloudevents/spec/tree/v0.3) | [v1.0](https://github.com/cloudevents/spec/tree/v1.0) |
-| ----------------------------- | --- | --- |
-| AVRO Event Format             | :x: | :x: |
-| JSON Event Format             | :heavy_check_mark: | :heavy_check_mark: |
+| Event Formats     | [v0.3](https://github.com/cloudevents/spec/tree/v0.3) | [v1.0](https://github.com/cloudevents/spec/tree/v1.0) |
+| ----------------- | ----------------------------------------------------- | ----------------------------------------------------- |
+| AVRO Event Format | :x:                                                   | :x:                                                   |
+| JSON Event Format | :heavy_check_mark:                                    | :heavy_check_mark:                                    |
+
 ---
 
-| Transport Protocols |  [v0.3](https://github.com/cloudevents/spec/tree/v0.3) | [v1.0](https://github.com/cloudevents/spec/tree/v1.0) |
-| ----------------------------- | --- | --- |
-| AMQP Protocol Binding         | :x: | :x: |
-| HTTP Protocol Binding         | :heavy_check_mark: | :heavy_check_mark: |
-| Kafka Protocol Binding        | :x: | :x: |
-| MQTT Protocol Binding         | :x: | :x: |
-| NATS Protocol Binding         | :x: | :x: |
+| Transport Protocols    | [v0.3](https://github.com/cloudevents/spec/tree/v0.3) | [v1.0](https://github.com/cloudevents/spec/tree/v1.0) |
+| ---------------------- | ----------------------------------------------------- | ----------------------------------------------------- |
+| AMQP Protocol Binding  | :x:                                                   | :x:                                                   |
+| HTTP Protocol Binding  | :heavy_check_mark:                                    | :heavy_check_mark:                                    |
+| Kafka Protocol Binding | :x:                                                   | :x:                                                   |
+| MQTT Protocol Binding  | :x:                                                   | :x:                                                   |
+| NATS Protocol Binding  | :x:                                                   | :x:                                                   |
 
 ## Community
 

--- a/src/event/cloudevent.ts
+++ b/src/event/cloudevent.ts
@@ -171,10 +171,11 @@ export class CloudEvent implements CloudEventV1, CloudEventV03 {
   /**
    * Emit this CloudEvent through the application
    *
-   * @return {CloudEvent} current CloudEvent object
+   * @param {boolean} ensureDelivery fail the promise if one listener fail
+   * @return {Promise<CloudEvent>} this
    */
-  public emit(): this {
-    Emitter.emitEvent(this);
+  public async emit(ensureDelivery = true): Promise<this> {
+    await Emitter.emitEvent(this, ensureDelivery);
     return this;
   }
 

--- a/src/event/cloudevent.ts
+++ b/src/event/cloudevent.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from "uuid";
+import { Emitter } from "..";
 
 import {
   CloudEventV03,
@@ -165,6 +166,16 @@ export class CloudEvent implements CloudEventV1, CloudEventV03 {
         throw new ValidationError("invalid payload", e);
       }
     }
+  }
+
+  /**
+   * Emit this CloudEvent through the application
+   *
+   * @return {CloudEvent} current CloudEvent object
+   */
+  public emit(): this {
+    Emitter.emitEvent(this);
+    return this;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { CloudEvent, Version } from "./event/cloudevent";
 import { ValidationError } from "./event/validation";
 import { CloudEventV03, CloudEventV03Attributes, CloudEventV1, CloudEventV1Attributes } from "./event/interfaces";
 
-import { Options, TransportFunction, EmitterFunction, emitterFor } from "./transport/emitter";
+import { Options, TransportFunction, EmitterFunction, emitterFor, Emitter } from "./transport/emitter";
 import { Headers, Mode, Binding, HTTP, Message, Serializer, Deserializer } from "./message";
 
 import CONSTANTS from "./constants";
@@ -28,6 +28,7 @@ export {
   TransportFunction,
   EmitterFunction,
   emitterFor,
+  Emitter,
   Options,
   // From Constants
   CONSTANTS,

--- a/src/transport/emitter.ts
+++ b/src/transport/emitter.ts
@@ -1,5 +1,6 @@
 import { CloudEvent } from "../event/cloudevent";
 import { HTTP, Message, Mode } from "../message";
+import { EventEmitter } from "events";
 
 /**
  * Options is an additional, optional dictionary of options that may
@@ -57,4 +58,45 @@ export function emitterFor(fn: TransportFunction, options = { binding: HTTP, mod
         throw new TypeError(`Unexpected transport mode: ${mode}`);
     }
   };
+}
+
+/**
+ * A static class to emit CloudEvents within an application
+ */
+export class Emitter extends EventEmitter {
+  /**
+   * Singleton store
+   */
+  static singleton: Emitter | undefined = undefined;
+
+  /**
+   * Create an Emitter
+   * On v4.0.0 this class will only remains as Singleton to allow using the
+   * EventEmitter of NodeJS
+   */
+  private constructor() {
+    super();
+  }
+
+  /**
+   * Return or create the Emitter singleton
+   *
+   * @return {Emitter} return Emitter singleton
+   */
+  static getSingleton(): Emitter {
+    if (!Emitter.singleton) {
+      Emitter.singleton = new Emitter();
+    }
+    return Emitter.singleton;
+  }
+
+  /**
+   * Emit an event inside this application
+   *
+   * @param {CloudEvent} event to emit
+   * @return {void}
+   */
+  static emitEvent(event: CloudEvent): void {
+    this.getSingleton().emit("event", event);
+  }
 }

--- a/test/integration/emitter_factory_test.ts
+++ b/test/integration/emitter_factory_test.ts
@@ -23,7 +23,7 @@ const data = {
   lunchBreak: "noon",
 };
 
-const fixture = new CloudEvent({
+export const fixture = new CloudEvent({
   source,
   type,
   data,
@@ -107,7 +107,13 @@ function testEmitter(fn: TransportFunction, bodyAttr: string) {
   });
 }
 
-function assertBinary(response: Record<string, string>) {
+/**
+ * Verify the received binary answer compare to the original fixture message
+ *
+ * @param {Record<string, Record<string, string>>} response received to compare to fixture
+ * @return {void} void
+ */
+export function assertBinary(response: Record<string, string>): void {
   expect(response.lunchBreak).to.equal(data.lunchBreak);
   expect(response["ce-type"]).to.equal(type);
   expect(response["ce-source"]).to.equal(source);
@@ -116,7 +122,13 @@ function assertBinary(response: Record<string, string>) {
   expect(response[`ce-${ext3Name}`]).to.deep.equal(ext3Value);
 }
 
-function assertStructured(response: Record<string, Record<string, string>>) {
+/**
+ * Verify the received structured answer compare to the original fixture message
+ *
+ * @param {Record<string, Record<string, string>>} response received to compare to fixture
+ * @return {void} void
+ */
+export function assertStructured(response: Record<string, Record<string, string>>): void {
   expect(response.data.lunchBreak).to.equal(data.lunchBreak);
   expect(response.type).to.equal(type);
   expect(response.source).to.equal(source);

--- a/test/integration/emitter_singleton_test.ts
+++ b/test/integration/emitter_singleton_test.ts
@@ -1,0 +1,55 @@
+import "mocha";
+
+import { emitterFor, HTTP, Mode, Message, Emitter } from "../../src";
+
+import { fixture, assertStructured } from "./emitter_factory_test";
+
+import { rejects, doesNotReject } from "assert";
+
+describe("Emitter Singleton", () => {
+  it("emit a Node.js 'cloudevent' event as an EventEmitter", async () => {
+    const msg: Message | unknown = await new Promise((resolve) => {
+      const fn = async (message: Message) => {
+        resolve(message);
+      };
+      const emitter = emitterFor(fn, { binding: HTTP, mode: Mode.STRUCTURED });
+      Emitter.on("cloudevent", emitter);
+
+      fixture.emit(false);
+    });
+    let body: unknown = (<Message>(<unknown>msg)).body;
+    if (typeof body === "string") {
+      body = JSON.parse(body);
+    }
+    assertStructured({ ...(<any>body), ...(<Message>(<unknown>msg)).headers });
+  });
+
+  it("emit a Node.js 'cloudevent' event as an EventEmitter with ensureDelivery", async () => {
+    let msg: Message | unknown = undefined;
+    const fn = async (message: Message) => {
+      msg = message;
+    };
+    const emitter = emitterFor(fn, { binding: HTTP, mode: Mode.STRUCTURED });
+    Emitter.on("cloudevent", emitter);
+    await fixture.emit(true);
+    let body: any = (<Message>msg).body;
+    if (typeof body === "string") {
+      body = JSON.parse(body);
+    }
+    assertStructured({ ...(<any>body), ...(<Message>(<unknown>msg)).headers });
+  });
+
+  it("emit a Node.js 'cloudevent' event as an EventEmitter with ensureDelivery Error", async () => {
+    const emitter = async () => {
+      throw new Error("Not sent");
+    };
+    Emitter.on("cloudevent", emitter);
+    // Should fail with emitWithEnsureDelivery
+    await rejects(() => fixture.emit(true));
+    // Should not fail with emitWithEnsureDelivery
+    // Work locally but not on Github Actions
+    if (!process.env.GITHUB_WORKFLOW) {
+      await doesNotReject(() => fixture.emit(false));
+    }
+  });
+});


### PR DESCRIPTION
## Proposed Changes

- Update Emitter from deprecated to singleton paradigm
- Allow implementing EventEmitter 
- It makes it cleaner as from any point in the source code you can just use `.emit()` of a CloudEvent to send it, you do not care about how it is sent to the right target


We might want to consider removing the EventEmitter and adding the listeners' management to be able to ensure async methods so we can emit and waiting for the event to be completely emitted before continue processing. (my favorite options will discuss it tomorrow during our call)

I was not able to avoid the warning for the `<any>` in the unit test, usage of `unknown` in the sdk is not helping there
