### PR TITLE
fix: Emitter should not extend EventEmitter

### DIFF
--- a/examples/typescript-ex/package.json
+++ b/examples/typescript-ex/package.json
@@ -23,9 +23,9 @@
     "posttest": "npm run check"
   },
   "devDependencies": {
-    "@types/node": "^8.9.0",
+    "@types/node": "^14.14.10",
     "gts": "^1.1.0",
-    "typescript": "~3.9.5"
+    "typescript": "~4.1.3"
   },
   "dependencies": {
     "cloudevents": "~4.0.0"

--- a/examples/typescript-ex/src/index.ts
+++ b/examples/typescript-ex/src/index.ts
@@ -1,14 +1,15 @@
-import { CloudEvent, CloudEventV1, HTTP } from "cloudevents";
+/* eslint-disable no-console */
+import { CloudEvent, HTTP } from "cloudevents";
 
 export function doSomeStuff(): void {
-  const myevent: CloudEventV1 = new CloudEvent({
+  const myevent: CloudEvent = new CloudEvent({
     source: "/source",
     type: "type",
     datacontenttype: "text/plain",
     dataschema: "https://d.schema.com/my.json",
     subject: "cha.json",
     data: "my-data",
-    extension1: "some extension data"
+    extension1: "some extension data",
   });
 
   console.log("My structured event:", myevent);
@@ -21,7 +22,7 @@ export function doSomeStuff(): void {
 
   // Typically used with an incoming HTTP request where myevent.format() is the actual
   // body of the HTTP
-  console.log("Received structured event:", HTTP.toEvent({headers, body: myevent}));
+  console.log("Received structured event:", HTTP.toEvent({ headers, body: myevent }));
 
   // ------ receiver binary
   const data = {
@@ -38,9 +39,8 @@ export function doSomeStuff(): void {
     "ce-extension1": "extension1",
   };
 
-  console.log("My binary event:", HTTP.toEvent({headers: attributes, body: data}));
-  console.log("My binary event extensions:", HTTP.toEvent({headers: attributes, body: data}));
-
+  console.log("My binary event:", HTTP.toEvent({ headers: attributes, body: data }));
+  console.log("My binary event extensions:", HTTP.toEvent({ headers: attributes, body: data }));
 }
 
 doSomeStuff();

--- a/package-lock.json
+++ b/package-lock.json
@@ -775,9 +775,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.13.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.30.tgz",
-      "integrity": "sha512-HmqFpNzp3TSELxU/bUuRK+xzarVOAsR00hzcvM0TXrMlt/+wcSLa5q6YhTb6/cA6wqDCZLDcfd8fSL95x5h7AA==",
+      "version": "14.14.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@types/cucumber": "^6.0.1",
     "@types/got": "^9.6.11",
     "@types/mocha": "^7.0.2",
-    "@types/node": "^13.13.9",
+    "@types/node": "^14.14.10",
     "@types/superagent": "^4.1.10",
     "@types/uuid": "^8.0.0",
     "@typescript-eslint/eslint-plugin": "^3.4.0",

--- a/src/transport/emitter.ts
+++ b/src/transport/emitter.ts
@@ -88,8 +88,8 @@ export class Emitter {
    * @param {Function} listener to call on event
    * @return {void}
    */
-  static on(event: string, listener: (...args: any[]) => void): void {
-    this.getInstance().on(event, listener);
+  static on(event: "cloudevent" | "newListener" | "removeListener", listener: (...args: any[]) => void): void {
+    Emitter.getInstance().on(event, listener);
   }
 
   /**

--- a/src/transport/emitter.ts
+++ b/src/transport/emitter.ts
@@ -46,14 +46,14 @@ export function emitterFor(fn: TransportFunction, options = { binding: HTTP, mod
     throw new TypeError("A TransportFunction is required");
   }
   const { binding, mode } = options;
-  return function emit(event: CloudEvent, options?: Options): Promise<unknown> {
-    options = options || {};
+  return function emit(event: CloudEvent, opts?: Options): Promise<unknown> {
+    opts = opts || {};
 
     switch (mode) {
       case Mode.BINARY:
-        return fn(binding.binary(event), options);
+        return fn(binding.binary(event), opts);
       case Mode.STRUCTURED:
-        return fn(binding.structured(event), options);
+        return fn(binding.structured(event), opts);
       default:
         throw new TypeError(`Unexpected transport mode: ${mode}`);
     }
@@ -63,29 +63,20 @@ export function emitterFor(fn: TransportFunction, options = { binding: HTTP, mod
 /**
  * A static class to emit CloudEvents within an application
  */
-export class Emitter extends EventEmitter {
+export class Emitter {
   /**
    * Singleton store
    */
-  static instance: Emitter | undefined = undefined;
-
-  /**
-   * Create an Emitter
-   * On v4.0.0 this class will only remains as Singleton to allow using the
-   * EventEmitter of NodeJS
-   */
-  private constructor() {
-    super();
-  }
+  static instance: EventEmitter | undefined = undefined;
 
   /**
    * Return or create the Emitter singleton
    *
    * @return {Emitter} return Emitter singleton
    */
-  static getInstance(): Emitter {
+  static getInstance(): EventEmitter {
     if (!Emitter.instance) {
-      Emitter.instance = new Emitter();
+      Emitter.instance = new EventEmitter();
     }
     return Emitter.instance;
   }
@@ -97,7 +88,7 @@ export class Emitter extends EventEmitter {
    * @param {Function} listener to call on event
    * @return {void}
    */
-  static on(event: "cloudevent" | "newListener" | "removeListener", listener: (...args: any[]) => void): void {
+  static on(event: string, listener: (...args: any[]) => void): void {
     this.getInstance().on(event, listener);
   }
 


### PR DESCRIPTION
This change modifies Emitter so that it does not directly extend the Node.js
EventEmitter class. Instead, it holds a singleton instance of an EventEmitter
but is not an instance of EventEmitter itself.

This commit also updates the typescript example to use a modern version of
@types/node and typescript.

Finally there are a few minor formatting changes picked up by eslint.

@loopingz if you have a chance to review this, that would be great. Thanks!

Fixes: https://github.com/cloudevents/sdk-javascript/issues/385

Signed-off-by: Lance Ball <lball@redhat.com>
