### PR TITLE
docs: fix 'npm run generate-docs'

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,6 @@
     "superagent": "^6.1.0",
     "ts-node": "^8.10.2",
     "typedoc": "^0.20.24",
-    "typedoc-clarity-theme": "~1.1.0",
     "typescript": "^3.8.3",
     "webpack": "^5.1.1",
     "webpack-cli": "^4.0.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,8 +21,6 @@
     "node_modules"
   ],
   "typedocOptions": {
-    "out": "docs",
-    "mode": "file",
-    "theme": "node_modules/typedoc-clarity-theme/bin"
+    "out": "docs"
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/cloudevents/sdk-javascript/issues/392

This commit also removes the external doc theme, since the new version
generates decent looking docs.

After this lands, docs should be published.

Signed-off-by: Lance Ball <lball@redhat.com>
