### PR TITLE
fix: defaults properly handled for emitterFor()

### DIFF
--- a/src/transport/emitter.ts
+++ b/src/transport/emitter.ts
@@ -28,6 +28,7 @@ export interface TransportFunction {
   (message: Message, options?: Options): Promise<unknown>;
 }
 
+const emitterDefaults = { binding: HTTP, mode: Mode.BINARY };
 /**
  * emitterFactory creates and returns an EmitterFunction using the supplied
  * TransportFunction. The returned EmitterFunction will invoke the Binding's
@@ -41,11 +42,11 @@ export interface TransportFunction {
  * @param {Mode} options.mode the encoding mode (Mode.BINARY or Mode.STRUCTURED)
  * @returns {EmitterFunction} an EmitterFunction to send events with
  */
-export function emitterFor(fn: TransportFunction, options = { binding: HTTP, mode: Mode.BINARY }): EmitterFunction {
+export function emitterFor(fn: TransportFunction, options = emitterDefaults): EmitterFunction {
   if (!fn) {
     throw new TypeError("A TransportFunction is required");
   }
-  const { binding, mode } = options;
+  const { binding, mode } = { ...emitterDefaults, ...options };
   return function emit(event: CloudEvent, opts?: Options): Promise<unknown> {
     opts = opts || {};
 

--- a/test/integration/emitter_factory_test.ts
+++ b/test/integration/emitter_factory_test.ts
@@ -79,10 +79,9 @@ describe("emitterFor() defaults", () => {
   it("Supports HTTP binding, structured mode", () => {
     function transport(message: Message): Promise<unknown> {
       console.error(message);
-      // A binary message will have the source attribute as a header
+      // A structured message will have the application/cloudevents+json header
       expect(message.headers["content-type"]).to.equal(CONSTANTS.DEFAULT_CE_CONTENT_TYPE);
       const body = JSON.parse(message.body as string);
-      /* @ts-ignore */
       expect(body.id).to.equal("1234");
       return Promise.resolve();
     }


### PR DESCRIPTION
Fixes: https://github.com/cloudevents/sdk-javascript/issues/391

Signed-off-by: Lance Ball <lball@redhat.com>

