### PR TITLE
chore: externalize remark-lint config

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,11 @@
+{
+  "remarkConfig": {
+    "plugins": [
+      "remark-preset-lint-recommended",
+      [
+        "remark-lint-list-item-indent",
+        "space"
+      ]
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,15 +18,6 @@
     "generate-docs": "typedoc --excludeNotDocumented --out docs src",
     "prepublishOnly": "npm run build"
   },
-  "remarkConfig": {
-    "plugins": [
-      "remark-preset-lint-recommended",
-      [
-        "remark-lint-list-item-indent",
-        "space"
-      ]
-    ]
-  },
   "files": [
     "dist",
     "bundles"


### PR DESCRIPTION
This way Codacy will use our configuration instead of its own.

Signed-off-by: Lance Ball <lball@redhat.com>

