### PR TITLE
chore: remove @types/axios and add axios in dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1485,9 +1485,9 @@
       "dev": true
     },
     "axios": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.0.tgz",
-      "integrity": "sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "dev": true,
       "requires": {
         "follow-redirects": "^1.10.0"
@@ -4010,9 +4010,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==",
       "dev": true
     },
     "for-in": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@types/ajv": "^1.0.0",
-    "@types/axios": "^0.14.0",
     "@types/chai": "^4.2.11",
     "@types/cucumber": "^6.0.1",
     "@types/got": "^9.6.11",
@@ -71,6 +70,7 @@
     "@types/uuid": "^8.0.0",
     "@typescript-eslint/eslint-plugin": "^3.4.0",
     "@typescript-eslint/parser": "^3.4.0",
+    "axios": "^0.21.1",
     "chai": "~4.2.0",
     "cucumber": "^6.0.5",
     "cucumber-pretty": "^6.0.0",


### PR DESCRIPTION
## Proposed Changes
This commit removes @types/axios from the devDependencies and replaces
it with straight up axios. The @types package is deprecated and has not
been updated in four years. Plus it was raising a security alert. Plus
axios publishes their own types now.

Signed-off-by: Lance Ball <lball@redhat.com>