### PR TITLE
src: be more forgiving parsing JSON as a string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -637,15 +637,6 @@
         "ajv": "*"
       }
     },
-    "@types/axios": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
-      "integrity": "sha1-7CMA++fX3d1+udOr+HmZlkyvzkY=",
-      "dev": true,
-      "requires": {
-        "axios": "*"
-      }
-    },
     "@types/cacheable-request": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -21,8 +21,7 @@ export class JSONParser implements Parser {
       // This is kind of a hack, but the payload data could be JSON in the form of a single
       // string, such as "some data". But without the quotes in the string, JSON.parse blows
       // up. We can check for this scenario and add quotes. Not sure if this is ideal.
-      const r = /^[[|{|"]/;
-      if (!r.test(payload)) {
+      if (!/^[[|{|"]/.test(payload)) {
         payload = `"${payload}"`;
       }
     }

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -17,6 +17,15 @@ export class JSONParser implements Parser {
    * @return {object} the parsed JSON payload.
    */
   parse(payload: Record<string, unknown> | string): string {
+    if (typeof payload === "string") {
+      // This is kind of a hack, but the payload data could be JSON in the form of a single
+      // string, such as "some data". But without the quotes in the string, JSON.parse blows
+      // up. We can check for this scenario and add quotes. Not sure if this is ideal.
+      const r = /^[[|{|"]/;
+      if (!r.test(payload)) {
+        payload = `"${payload}"`;
+      }
+    }
     if (this.decorator) {
       payload = this.decorator.parse(payload);
     }

--- a/test/integration/parser_test.ts
+++ b/test/integration/parser_test.ts
@@ -59,7 +59,6 @@ describe("JSON Event Format Parser", () => {
     const payload = "I am a string!";
     const parser = new Parser();
 
-    // TODO: Should the parser catch the SyntaxError and re-throw a ValidationError?
     expect(parser.parse(payload)).to.equal("I am a string!");
   });
 

--- a/test/integration/parser_test.ts
+++ b/test/integration/parser_test.ts
@@ -47,11 +47,20 @@ describe("JSON Event Format Parser", () => {
 
   it("Throw error when payload is an invalid JSON", () => {
     // setup
-    const payload = "gg";
+    const payload = "{gg";
     const parser = new Parser();
 
     // TODO: Should the parser catch the SyntaxError and re-throw a ValidationError?
-    expect(parser.parse.bind(parser, payload)).to.throw(SyntaxError, "Unexpected token g in JSON at position 0");
+    expect(parser.parse.bind(parser, payload)).to.throw(SyntaxError, "Unexpected token g in JSON at position 1");
+  });
+
+  it("Accepts a string as valid JSON", () => {
+    // setup
+    const payload = "I am a string!";
+    const parser = new Parser();
+
+    // TODO: Should the parser catch the SyntaxError and re-throw a ValidationError?
+    expect(parser.parse(payload)).to.equal("I am a string!");
   });
 
   it("Must accept when the payload is a string well formed as JSON", () => {


### PR DESCRIPTION
A simple string is considered valid JSON. However, our parsers do
not accept that unless the string has quotation marks. This commit
modifies the parser to look for strings declared as application/json
which do not begin with '[' '{' or '"' and surrounds them with
quotes.

Signed-off-by: Lance Ball <lball@redhat.com>

<!-- General PR guidelines:
Thanks for taking the time to contribute to this project!

When submitting a pull request, please be sure to use the --signoff
flag for your commits. If you haven't done this already, you can
amend your most recent commit with "git commit --amend --signoff".

If your change fixes an existing problem, please add a close hook
to your commit message. For example, if your PR fixes issue #280
include the following in the description:

  Fixes: https://github.com/cloudevents/sdk-javascript/issues/280
 -->
## Proposed Changes

## Description
