### PR TITLE
fix: do not modify incoming event's specversion

### DIFF
--- a/src/message/http/index.ts
+++ b/src/message/http/index.ts
@@ -87,11 +87,8 @@ export function isEvent(message: Message): boolean {
 export function deserialize(message: Message): CloudEvent {
   const cleanHeaders: Headers = sanitize(message.headers);
   const mode: Mode = getMode(cleanHeaders);
-  let version = getVersion(mode, cleanHeaders, message.body);
-  if (version !== Version.V03 && version !== Version.V1) {
-    console.error(`Unknown spec version ${version}. Default to ${Version.V1}`);
-    version = Version.V1;
-  }
+  const version = getVersion(mode, cleanHeaders, message.body);
+
   switch (mode) {
     case Mode.BINARY:
       return parseBinary(message, version);
@@ -160,7 +157,7 @@ function parseBinary(message: Message, version: Version): CloudEvent {
   const sanitizedHeaders = sanitize(headers);
 
   const eventObj: { [key: string]: unknown | string | Record<string, unknown> } = {};
-  const parserMap: Record<string, MappedParser> = version === Version.V1 ? v1binaryParsers : v03binaryParsers;
+  const parserMap: Record<string, MappedParser> = version === Version.V03 ? v03binaryParsers : v1binaryParsers;
 
   for (const header in parserMap) {
     if (sanitizedHeaders[header]) {
@@ -217,13 +214,13 @@ function parseStructured(message: Message, version: Version): CloudEvent {
   const incoming = { ...(parser.parse(payload as string) as Record<string, unknown>) };
 
   const eventObj: { [key: string]: unknown } = {};
-  const parserMap: Record<string, MappedParser> = version === Version.V1 ? v1structuredParsers : v03structuredParsers;
+  const parserMap: Record<string, MappedParser> = version === Version.V03 ? v03structuredParsers : v1structuredParsers;
 
   for (const key in parserMap) {
     const property = incoming[key];
     if (property) {
-      const parser: MappedParser = parserMap[key];
-      eventObj[parser.name] = parser.parser.parse(property as string);
+      const mappedParser: MappedParser = parserMap[key];
+      eventObj[mappedParser.name] = mappedParser.parser.parse(property as string);
     }
     delete incoming[key];
   }

--- a/test/integration/message_test.ts
+++ b/test/integration/message_test.ts
@@ -76,7 +76,9 @@ describe("HTTP transport", () => {
       },
     };
     expect(HTTP.isEvent(message)).to.be.true;
-    expect(HTTP.toEvent(message)).not.to.throw;
+    const event: CloudEvent = HTTP.toEvent(message);
+    expect(event.specversion).to.equal("11.8");
+    expect(event.validate()).to.be.false;
   });
 
   it("Can detect CloudEvent structured Messages with weird versions", () => {


### PR DESCRIPTION
Even if the specversion is totally invalid, we should not change the valuereceived in an incoming `Message`. Previously we defaulted to 1.0 if we did not recognize the version number. This commit changes that, leaving the value unmodified. We default to parsing this mystery event with the 1.0 spec. When the event is validated with `event.validate()` we return `false`.

One additional small change to eliminate a prettier warning about `pasrer` being previously declared.

As discussed in #332 this same problem exists for both `id` and `time`. However, I am not addressing these at the moment. I think we should simply reconsider ANY defaults. Regarding `id` and `time`, the behavior is different with each. With `id` missing, it is not possible to parse an incoming `Message`, since we use the ID to determine if it's a structured event. With no `id` present, it's just not an event. The spec states that you determine whether an incoming HTTP request is a structured cloud event by checking for `ce-id` in the headers. So... :shrug: 

Regarding `time`, it's not currently possible to construct an event that does NOT have a `time` property. When using the `new CloudEvent()` constructor, a default value is created if one isn't provided. However, `event` objects are read only, so setting `event.time = undefined` after the fact doesn't work. If instead, we accept the incoming message, create an event, check to see if the original message had a `time` attribute, and if not use `event.cloneWith({ time: undefined })` - we're right back where we started, since `cloneWith()` uses the constructor internally.

Given that, I think the only answer is for us to remove the default value generated for `time`.

Fixes: https://github.com/cloudevents/sdk-javascript/issues/332
Fixes: https://github.com/cloudevents/sdk-javascript/issues/333

Signed-off-by: Lance Ball <lball@redhat.com>
