### PR TITLE
feat: add native logging with headers and body to CloudEvent

### DIFF
--- a/src/event/cloudevent.ts
+++ b/src/event/cloudevent.ts
@@ -198,8 +198,9 @@ See: https://github.com/cloudevents/spec/blob/v1.0/spec.md#type-system`);
 
   /**
    * The native `console.log` value of the CloudEvent.
+   * @returns The string representation of the CloudEvent.
    */
-  [Symbol.for('nodejs.util.inspect.custom')](depth: any, opts: any) {
+  [Symbol.for("nodejs.util.inspect.custom")]() {
     return this.toString();
   }
 }

--- a/src/event/cloudevent.ts
+++ b/src/event/cloudevent.ts
@@ -198,7 +198,7 @@ See: https://github.com/cloudevents/spec/blob/v1.0/spec.md#type-system`);
 
   /**
    * The native `console.log` value of the CloudEvent.
-   * @returns The string representation of the CloudEvent.
+   * @return The string representation of the CloudEvent.
    */
   [Symbol.for("nodejs.util.inspect.custom")]() {
     return this.toString();

--- a/src/event/cloudevent.ts
+++ b/src/event/cloudevent.ts
@@ -198,9 +198,9 @@ See: https://github.com/cloudevents/spec/blob/v1.0/spec.md#type-system`);
 
   /**
    * The native `console.log` value of the CloudEvent.
-   * @return The string representation of the CloudEvent.
+   * @return {string} The string representation of the CloudEvent.
    */
-  [Symbol.for("nodejs.util.inspect.custom")]() {
+  [Symbol.for("nodejs.util.inspect.custom")](): string {
     return this.toString();
   }
 }

--- a/src/event/cloudevent.ts
+++ b/src/event/cloudevent.ts
@@ -9,6 +9,7 @@ import { Emitter } from "..";
 import { CloudEventV1, CloudEventV1Attributes, CloudEventV1OptionalAttributes } from "./interfaces";
 import { validateCloudEvent } from "./spec";
 import { ValidationError, isBinary, asBase64, isValidType } from "./validation";
+import * as util from 'util';
 
 /**
  * An enum representing the CloudEvent specification version
@@ -194,5 +195,12 @@ See: https://github.com/cloudevents/spec/blob/v1.0/spec.md#type-system`);
     strict = true,
   ): CloudEvent {
     return new CloudEvent(Object.assign({}, this.toJSON(), options) as CloudEvent, strict);
+  }
+
+  /**
+   * The native `console.log` value of the CloudEvent.
+   */
+  [util.inspect.custom](depth: any, opts: any) {
+    return this.toString();
   }
 }

--- a/src/event/cloudevent.ts
+++ b/src/event/cloudevent.ts
@@ -9,7 +9,6 @@ import { Emitter } from "..";
 import { CloudEventV1, CloudEventV1Attributes, CloudEventV1OptionalAttributes } from "./interfaces";
 import { validateCloudEvent } from "./spec";
 import { ValidationError, isBinary, asBase64, isValidType } from "./validation";
-import * as util from 'util';
 
 /**
  * An enum representing the CloudEvent specification version
@@ -200,7 +199,7 @@ See: https://github.com/cloudevents/spec/blob/v1.0/spec.md#type-system`);
   /**
    * The native `console.log` value of the CloudEvent.
    */
-  [util.inspect.custom](depth: any, opts: any) {
+  [Symbol.for('nodejs.util.inspect.custom')](depth: any, opts: any) {
     return this.toString();
   }
 }

--- a/test/integration/cloud_event_test.ts
+++ b/test/integration/cloud_event_test.ts
@@ -57,7 +57,7 @@ describe("A CloudEvent", () => {
 
   it("serializes as JSON with raw log", () => {
     const ce = new CloudEvent({ ...fixture, data: { lunch: "tacos" } });
-    expect(ce.toString()).to.deep.equal(JSON.stringify(ce));
+    expect(ce.toString()).to.deep.equal(ce[Symbol.for("nodejs.util.inspect.custom")]());
   });
 
   it("Throw a validation error for invalid extension names", () => {

--- a/test/integration/cloud_event_test.ts
+++ b/test/integration/cloud_event_test.ts
@@ -57,7 +57,9 @@ describe("A CloudEvent", () => {
 
   it("serializes as JSON with raw log", () => {
     const ce = new CloudEvent({ ...fixture, data: { lunch: "tacos" } });
-    expect(ce.toString()).to.deep.equal(JSON.stringify(ce));
+    const inspectSymbol = (Symbol.for("nodejs.util.inspect.custom") as unknown) as string;
+    const ceToString = (ce[inspectSymbol] as CallableFunction).bind(ce);
+    expect(ce.toString()).to.deep.equal(ceToString());
   });
 
   it("Throw a validation error for invalid extension names", () => {

--- a/test/integration/cloud_event_test.ts
+++ b/test/integration/cloud_event_test.ts
@@ -55,6 +55,11 @@ describe("A CloudEvent", () => {
     expect(new CloudEvent(JSON.parse(JSON.stringify(ce)))).to.deep.equal(ce);
   });
 
+  it("serializes as JSON with raw log", () => {
+    const ce = new CloudEvent({ ...fixture, data: { lunch: "tacos" } });
+    expect(ce.toString()).to.deep.equal(JSON.stringify(ce));
+  });
+
   it("Throw a validation error for invalid extension names", () => {
     expect(() => {
       new CloudEvent({ "ext-1": "extension1", ...fixture });

--- a/test/integration/cloud_event_test.ts
+++ b/test/integration/cloud_event_test.ts
@@ -57,7 +57,7 @@ describe("A CloudEvent", () => {
 
   it("serializes as JSON with raw log", () => {
     const ce = new CloudEvent({ ...fixture, data: { lunch: "tacos" } });
-    expect(ce.toString()).to.deep.equal(ce[Symbol.for("nodejs.util.inspect.custom")]());
+    expect(ce.toString()).to.deep.equal(JSON.stringify(ce));
   });
 
   it("Throw a validation error for invalid extension names", () => {


### PR DESCRIPTION
Add better native logging to the `CloudEvent` class.

## Proposed Changes

Logging a `CloudEvent` should call the `toString` of the `CloudEvent`.

Fixes https://github.com/cloudevents/sdk-javascript/issues/432