### PR TITLE
fix: ensure source property has min length of 1

### DIFF
--- a/src/event/schemas.ts
+++ b/src/event/schemas.ts
@@ -79,6 +79,7 @@ export const schemaV1 = {
     source: {
       format: "uri-reference",
       type: "string",
+      minLength: 1,
     },
   },
   type: "object",

--- a/test/integration/cloud_event_test.ts
+++ b/test/integration/cloud_event_test.ts
@@ -209,4 +209,20 @@ describe("A 1.0 CloudEvent", () => {
     expect(obj.source).to.equal(source);
     expect(obj.specversion).to.equal(Version.V1);
   });
+
+  it(" throws if the provded source is empty string", () => {
+    try {
+      new CloudEvent({
+        id: "0815",
+        specversion: "1.0",
+        type: "my.event.type",
+        source: "",
+      });
+    } catch (err) {
+      expect(err).to.be.instanceOf(TypeError);
+      expect(err.message).to.include("invalid payload");
+      expect(err.errors[0].dataPath).to.equal(".source");
+      expect(err.errors[0].keyword).to.equal("minLength");
+    }
+  });
 });

--- a/test/integration/cloud_event_test.ts
+++ b/test/integration/cloud_event_test.ts
@@ -210,7 +210,7 @@ describe("A 1.0 CloudEvent", () => {
     expect(obj.specversion).to.equal(Version.V1);
   });
 
-  it(" throws if the provded source is empty string", () => {
+  it("throws if the provded source is empty string", () => {
     try {
       new CloudEvent({
         id: "0815",


### PR DESCRIPTION
Fixes: https://github.com/cloudevents/sdk-javascript/issues/383

Signed-off-by: Lance Ball <lball@redhat.com>
