### PR TITLE
chore: add test for text/plain data

### DIFF
--- a/test/integration/message_test.ts
+++ b/test/integration/message_test.ts
@@ -64,6 +64,19 @@ describe("HTTP transport", () => {
     expect(HTTP.isEvent(message)).to.be.true;
   });
 
+  it("Handles CloudEvents with datacontenttype of text/plain", () => {
+    const message: Message = HTTP.binary(
+      new CloudEvent({
+        source: "/test",
+        type: "example",
+        datacontenttype: "text/plain",
+        data: "Hello, friends!",
+      }),
+    );
+    const event = HTTP.toEvent(message);
+    expect(event.validate()).to.be.true;
+  });
+
   it("Respects extension attribute casing (even if against spec)", () => {
     // Now create a message that is an event
     const message = {


### PR DESCRIPTION

## Proposed Changes

Simply adds an explicit test for a CE with data in `text/plain` format.


Signed-off-by: Lance Ball <lball@redhat.com>
