### PR TITLE
feat: use generic type for CloudEvent data

### DIFF
--- a/src/event/cloudevent.ts
+++ b/src/event/cloudevent.ts
@@ -51,7 +51,7 @@ export class CloudEvent<T = undefined> implements CloudEventV1<T> {
    * @param {object} event the event properties
    * @param {boolean?} strict whether to perform event validation when creating the object - default: true
    */
-  constructor(event: Partial<CloudEventV1<T>>, strict = true) {
+  constructor(event: Pick<Partial<CloudEventV1<T>>, "source">, strict = true) {
     // copy the incoming event so that we can delete properties as we go
     // everything left after we have deleted know properties becomes an extension
     const properties = { ...event };
@@ -146,7 +146,7 @@ See: https://github.com/cloudevents/spec/blob/v1.0/spec.md#type-system`);
   toJSON(): Record<string, unknown> {
     const event = { ...this };
     event.time = new Date(this.time as string).toISOString();
-    event.data = (!isBinary(this.data) ? this.data : undefined) as T;
+    event.data = !isBinary(this.data) ? this.data : undefined;
     return event;
   }
 

--- a/src/event/cloudevent.ts
+++ b/src/event/cloudevent.ts
@@ -51,7 +51,7 @@ export class CloudEvent<T = undefined> implements CloudEventV1<T> {
    * @param {object} event the event properties
    * @param {boolean?} strict whether to perform event validation when creating the object - default: true
    */
-  constructor(event: Pick<Partial<CloudEventV1<T>>, "source">, strict = true) {
+  constructor(event: Partial<CloudEventV1<T>>, strict = true) {
     // copy the incoming event so that we can delete properties as we go
     // everything left after we have deleted know properties becomes an extension
     const properties = { ...event };

--- a/src/event/cloudevent.ts
+++ b/src/event/cloudevent.ts
@@ -32,7 +32,7 @@ export class CloudEvent<T = undefined> implements CloudEventV1<T> {
   dataschema?: string;
   subject?: string;
   time?: string;
-  #_data?: T = undefined;
+  #_data?: T;
   data_base64?: string;
 
   // Extensions should not exist as it's own object, but instead
@@ -132,7 +132,7 @@ See: https://github.com/cloudevents/spec/blob/v1.0/spec.md#type-system`);
 
   set data(value: T | undefined) {
     if (isBinary(value)) {
-      this.data_base64 = asBase64((value as unknown) as Uint32Array);
+      this.data_base64 = asBase64(value);
     }
     this.#_data = value;
   }
@@ -184,14 +184,27 @@ See: https://github.com/cloudevents/spec/blob/v1.0/spec.md#type-system`);
 
   /**
    * Clone a CloudEvent with new/update attributes
-   * @param {object} options attributes to augment the CloudEvent with
+   * @param {object} options attributes to augment the CloudEvent with an `data` property
+   * @param {boolean} strict whether or not to use strict validation when cloning (default: true)
+   * @throws if the CloudEvent does not conform to the schema
+   * @return {CloudEvent} returns a new CloudEvent<T>
+   */
+  public cloneWith(options: Partial<Exclude<CloudEventV1<never>, "data">>, strict?: boolean): CloudEvent<T>;
+  /**
+   * Clone a CloudEvent with new/update attributes
+   * @param {object} options attributes to augment the CloudEvent with a `data` property
+   * @param {boolean} strict whether or not to use strict validation when cloning (default: true)
+   * @throws if the CloudEvent does not conform to the schema
+   * @return {CloudEvent} returns a new CloudEvent<D>
+   */
+  public cloneWith<D>(options: Partial<CloudEvent<D>>, strict?: boolean): CloudEvent<D>;
+  /**
+   * Clone a CloudEvent with new/update attributes
+   * @param {object} options attributes to augment the CloudEvent
    * @param {boolean} strict whether or not to use strict validation when cloning (default: true)
    * @throws if the CloudEvent does not conform to the schema
    * @return {CloudEvent} returns a new CloudEvent
    */
-  public cloneWith(options: Partial<Exclude<CloudEventV1<never>, "data">>, strict?: boolean): CloudEvent<T>;
-  // If the cloned event has a data property, the returned event should use the provided type
-  public cloneWith<D>(options: Partial<CloudEvent<D>>, strict?: boolean): CloudEvent<D>;
   public cloneWith<D>(options: Partial<CloudEventV1<D>>, strict = true): CloudEvent<D | T> {
     return new CloudEvent(Object.assign({}, this.toJSON(), options), strict);
   }

--- a/src/event/interfaces.ts
+++ b/src/event/interfaces.ts
@@ -7,7 +7,7 @@
  * The object interface for CloudEvents 1.0.
  * @see https://github.com/cloudevents/spec/blob/v1.0/spec.md
  */
-export interface CloudEventV1 extends CloudEventV1Attributes {
+export interface CloudEventV1<T> extends CloudEventV1Attributes<T> {
   // REQUIRED Attributes
   /**
    * [REQUIRED] Identifies the event. Producers MUST ensure that `source` + `id`
@@ -30,7 +30,7 @@ export interface CloudEventV1 extends CloudEventV1Attributes {
   specversion: string;
 }
 
-export interface CloudEventV1Attributes extends CloudEventV1OptionalAttributes {
+export interface CloudEventV1Attributes<T> extends CloudEventV1OptionalAttributes<T> {
   /**
    * [REQUIRED] Identifies the context in which an event happened. Often this
    * will include information such as the type of the event source, the
@@ -65,7 +65,7 @@ export interface CloudEventV1Attributes extends CloudEventV1OptionalAttributes {
   type: string;
 }
 
-export interface CloudEventV1OptionalAttributes {
+export interface CloudEventV1OptionalAttributes<T> {
   /**
    * The following fields are optional.
    */
@@ -126,7 +126,7 @@ export interface CloudEventV1OptionalAttributes {
    * specified by the datacontenttype attribute (e.g. application/json), and adheres
    * to the dataschema format when those respective attributes are present.
    */
-  data?: Record<string, unknown | string | number | boolean> | string | number | boolean | null | unknown;
+  data?: T;
 
   /**
    * [OPTIONAL] The event payload encoded as base64 data. This is used when the

--- a/src/event/spec.ts
+++ b/src/event/spec.ts
@@ -21,7 +21,7 @@ ajv.addFormat("js-date-time", function (dateTimeString) {
 
 const isValidAgainstSchemaV1 = ajv.compile(schemaV1);
 
-export function validateCloudEvent(event: CloudEventV1): boolean {
+export function validateCloudEvent<T>(event: CloudEventV1<T>): boolean {
   if (event.specversion === Version.V1) {
     if (!isValidAgainstSchemaV1(event)) {
       throw new ValidationError("invalid payload", isValidAgainstSchemaV1.errors);

--- a/src/event/validation.ts
+++ b/src/event/validation.ts
@@ -35,8 +35,8 @@ export const isDefined = (v: unknown): boolean => v !== null && typeof v !== "un
 
 export const isBoolean = (v: unknown): boolean => typeof v === "boolean";
 export const isInteger = (v: unknown): boolean => Number.isInteger(v as number);
-export const isDate = (v: unknown): boolean => v instanceof Date;
-export const isBinary = (v: unknown): boolean => v instanceof Uint32Array;
+export const isDate = (v: unknown): v is Date => v instanceof Date;
+export const isBinary = (v: unknown): v is Uint32Array => v instanceof Uint32Array;
 
 export const isStringOrThrow = (v: unknown, t: Error): boolean =>
   isString(v)
@@ -75,7 +75,7 @@ export const isBuffer = (value: unknown): boolean => value instanceof Buffer;
 
 export const asBuffer = (value: string | Buffer | Uint32Array): Buffer =>
   isBinary(value)
-    ? Buffer.from(value as string)
+    ? Buffer.from((value as unknown) as string)
     : isBuffer(value)
     ? (value as Buffer)
     : (() => {

--- a/src/message/http/headers.ts
+++ b/src/message/http/headers.ts
@@ -24,7 +24,7 @@ export const requiredHeaders = [
  * @param {CloudEvent} event a CloudEvent
  * @returns {Object} the headers that will be sent for the event
  */
-export function headersFor(event: CloudEvent): Headers {
+export function headersFor<T>(event: CloudEvent<T>): Headers {
   const headers: Headers = {};
   let headerMap: Readonly<{ [key: string]: MappedParser }>;
   if (event.specversion === Version.V1) {

--- a/src/message/index.ts
+++ b/src/message/index.ts
@@ -61,7 +61,7 @@ export enum Mode {
  * @interface
  */
 export interface Serializer {
-  (event: CloudEvent): Message;
+  <T>(event: CloudEvent<T>): Message;
 }
 
 /**
@@ -70,7 +70,7 @@ export interface Serializer {
  * @interface
  */
 export interface Deserializer {
-  (message: Message): CloudEvent;
+  <T>(message: Message): CloudEvent<T>;
 }
 
 /**

--- a/src/transport/emitter.ts
+++ b/src/transport/emitter.ts
@@ -23,7 +23,7 @@ export interface Options {
  * @interface
  */
 export interface EmitterFunction {
-  (event: CloudEvent, options?: Options): Promise<unknown>;
+  <T>(event: CloudEvent<T>, options?: Options): Promise<unknown>;
 }
 
 /**
@@ -56,7 +56,7 @@ export function emitterFor(fn: TransportFunction, options = emitterDefaults): Em
     throw new TypeError("A TransportFunction is required");
   }
   const { binding, mode }: any = { ...emitterDefaults, ...options };
-  return function emit(event: CloudEvent, opts?: Options): Promise<unknown> {
+  return function emit<T>(event: CloudEvent<T>, opts?: Options): Promise<unknown> {
     opts = opts || {};
 
     switch (mode) {
@@ -109,7 +109,7 @@ export class Emitter {
    * @param {boolean} ensureDelivery fail the promise if one listener fails
    * @return {void}
    */
-  static async emitEvent(event: CloudEvent, ensureDelivery = true): Promise<void> {
+  static async emitEvent<T>(event: CloudEvent<T>, ensureDelivery = true): Promise<void> {
     if (!ensureDelivery) {
       // Ensure delivery is disabled so we don't wait for Promise
       Emitter.getInstance().emit("cloudevent", event);

--- a/test/integration/cloud_event_test.ts
+++ b/test/integration/cloud_event_test.ts
@@ -15,7 +15,7 @@ const type = "org.cncf.cloudevents.example";
 const source = "http://unit.test";
 const id = "b46cf653-d48a-4b90-8dfa-355c01061361";
 
-const fixture: CloudEventV1 = {
+const fixture: CloudEventV1<string> = {
   id,
   specversion: Version.V1,
   source,
@@ -34,17 +34,17 @@ describe("A CloudEvent", () => {
   });
 
   it("Can be constructed with loose validation", () => {
-    const ce = new CloudEvent({} as CloudEventV1, false);
+    const ce = new CloudEvent({} as CloudEventV1<string>, false);
     expect(ce).to.be.instanceOf(CloudEvent);
   });
 
   it("Loosely validated events can be cloned", () => {
-    const ce = new CloudEvent({} as CloudEventV1, false);
+    const ce = new CloudEvent({} as CloudEventV1<string>, false);
     expect(ce.cloneWith({}, false)).to.be.instanceOf(CloudEvent);
   });
 
   it("Loosely validated events throw when validated", () => {
-    const ce = new CloudEvent({} as CloudEventV1, false);
+    const ce = new CloudEvent({} as CloudEventV1<string>, false);
     expect(ce.validate).to.throw(ValidationError, "invalid payload");
   });
 

--- a/test/integration/cloud_event_test.ts
+++ b/test/integration/cloud_event_test.ts
@@ -8,14 +8,13 @@ import fs from "fs";
 
 import { expect } from "chai";
 import { CloudEvent, ValidationError, Version } from "../../src";
-import { CloudEventV1 } from "../../src/event/interfaces";
 import { asBase64 } from "../../src/event/validation";
 
 const type = "org.cncf.cloudevents.example";
 const source = "http://unit.test";
 const id = "b46cf653-d48a-4b90-8dfa-355c01061361";
 
-const fixture: CloudEventV1<string> = {
+const fixture = {
   id,
   specversion: Version.V1,
   source,
@@ -34,17 +33,17 @@ describe("A CloudEvent", () => {
   });
 
   it("Can be constructed with loose validation", () => {
-    const ce = new CloudEvent({} as CloudEventV1<string>, false);
+    const ce = new CloudEvent({}, false);
     expect(ce).to.be.instanceOf(CloudEvent);
   });
 
   it("Loosely validated events can be cloned", () => {
-    const ce = new CloudEvent({} as CloudEventV1<string>, false);
+    const ce = new CloudEvent({}, false);
     expect(ce.cloneWith({}, false)).to.be.instanceOf(CloudEvent);
   });
 
   it("Loosely validated events throw when validated", () => {
-    const ce = new CloudEvent({} as CloudEventV1<string>, false);
+    const ce = new CloudEvent({}, false);
     expect(ce.validate).to.throw(ValidationError, "invalid payload");
   });
 

--- a/test/integration/message_test.ts
+++ b/test/integration/message_test.ts
@@ -77,7 +77,7 @@ describe("HTTP transport", () => {
       },
     };
     expect(HTTP.isEvent(message)).to.be.true;
-    const event: CloudEvent = HTTP.toEvent(message);
+    const event: CloudEvent<Record<string, string>> = HTTP.toEvent(message);
     expect(event.LUNCH).to.equal("tacos");
     expect(function () {
       event.validate();
@@ -96,7 +96,7 @@ describe("HTTP transport", () => {
       },
     };
     expect(HTTP.isEvent(message)).to.be.true;
-    const event: CloudEvent = HTTP.toEvent(message);
+    const event: CloudEvent<Record<string, string>> = HTTP.toEvent(message);
     expect(event.specversion).to.equal("11.8");
     expect(event.validate()).to.be.false;
   });
@@ -167,7 +167,7 @@ describe("HTTP transport", () => {
   });
 
   describe("Specification version V1", () => {
-    const fixture: CloudEvent = new CloudEvent({
+    const fixture: CloudEvent<any> = new CloudEvent({
       specversion: Version.V1,
       id,
       type,
@@ -270,7 +270,7 @@ describe("HTTP transport", () => {
   });
 
   describe("Specification version V03", () => {
-    const fixture: CloudEvent = new CloudEvent({
+    const fixture: CloudEvent<any> = new CloudEvent({
       specversion: Version.V03,
       id,
       type,

--- a/test/integration/message_test.ts
+++ b/test/integration/message_test.ts
@@ -77,7 +77,7 @@ describe("HTTP transport", () => {
       },
     };
     expect(HTTP.isEvent(message)).to.be.true;
-    const event: CloudEvent<Record<string, string>> = HTTP.toEvent(message);
+    const event = HTTP.toEvent(message);
     expect(event.LUNCH).to.equal("tacos");
     expect(function () {
       event.validate();
@@ -96,7 +96,7 @@ describe("HTTP transport", () => {
       },
     };
     expect(HTTP.isEvent(message)).to.be.true;
-    const event: CloudEvent<Record<string, string>> = HTTP.toEvent(message);
+    const event = HTTP.toEvent(message);
     expect(event.specversion).to.equal("11.8");
     expect(event.validate()).to.be.false;
   });
@@ -167,7 +167,7 @@ describe("HTTP transport", () => {
   });
 
   describe("Specification version V1", () => {
-    const fixture: CloudEvent<any> = new CloudEvent({
+    const fixture = new CloudEvent({
       specversion: Version.V1,
       id,
       type,
@@ -270,7 +270,7 @@ describe("HTTP transport", () => {
   });
 
   describe("Specification version V03", () => {
-    const fixture: CloudEvent<any> = new CloudEvent({
+    const fixture = new CloudEvent({
       specversion: Version.V03,
       id,
       type,

--- a/test/integration/spec_1_tests.ts
+++ b/test/integration/spec_1_tests.ts
@@ -19,7 +19,7 @@ const data = {
 };
 const subject = "subject-x0";
 
-let cloudevent = new CloudEvent<any>({
+let cloudevent = new CloudEvent({
   specversion: Version.V1,
   id,
   source,
@@ -164,13 +164,13 @@ describe("CloudEvents Spec v1.0", () => {
       expect(cloudevent.data).to.deep.equal(data);
     });
 
-    it("should maintain the type of data when no data content type", () => {
-      const dct = cloudevent.datacontenttype;
-      cloudevent = cloudevent.cloneWith({ datacontenttype: undefined });
-      cloudevent.data = JSON.stringify(data);
-
-      expect(typeof cloudevent.data).to.equal("string");
-      cloudevent = cloudevent.cloneWith({ datacontenttype: dct });
+    it("should maintain the type of data when no datacontenttype is provided", () => {
+      const ce = new CloudEvent({
+        source: "/cloudevents/test",
+        type: "cloudevents.test",
+        data: JSON.stringify(data),
+      });
+      expect(typeof ce.data).to.equal("string");
     });
 
     it("should be ok when type is 'Uint32Array' for 'Binary'", () => {
@@ -179,9 +179,8 @@ describe("CloudEvents Spec v1.0", () => {
       const dataBinary = Uint32Array.from(dataString, (c) => c.codePointAt(0) as number);
       const expected = asBase64(dataBinary);
 
-      cloudevent = cloudevent.cloneWith({ datacontenttype: "text/plain", data: dataBinary });
-
-      expect(cloudevent.data_base64).to.equal(expected);
+      const ce = cloudevent.cloneWith({ datacontenttype: "text/plain", data: dataBinary });
+      expect(ce.data_base64).to.equal(expected);
     });
   });
 });

--- a/test/integration/spec_1_tests.ts
+++ b/test/integration/spec_1_tests.ts
@@ -19,7 +19,7 @@ const data = {
 };
 const subject = "subject-x0";
 
-let cloudevent = new CloudEvent({
+let cloudevent = new CloudEvent<any>({
   specversion: Version.V1,
   id,
   source,


### PR DESCRIPTION
Instead of using a big union of types, use a generic type for event data.

Fixes: https://github.com/cloudevents/sdk-javascript/issues/445

Signed-off-by: Lance Ball <lball@redhat.com>
