### PR TITLE
docs: add TS examples for CloudEvent usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,29 @@ const ce = new CloudEvent({...});
 const ce2 = ce.cloneWith({extension: "Value"});
 ```
 
+You can create a `CloudEvent` object in many ways, for example:
+
+```js
+import { CloudEvent, CloudEventV1, CloudEventV1Attributes } from "cloudevents";
+const ce: CloudEventV1<string> = {
+    specversion: '1.0',
+    source: '/some/source',
+    type: 'example',
+    id: '1234'
+};
+const event = new CloudEvent(ce);
+const ce2: CloudEventV1Attributes<string> = {
+    specversion: '1.0',
+    source: '/some/source',
+    type: 'example',
+};
+const event2 = new CloudEvent(ce2);
+const event3 = new CloudEvent({
+    source: '/some/source',
+    type: 'example',
+});
+```
+
 ### Example Applications
 
 There are a few trivial example applications in

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ const ce = new CloudEvent({...});
 const ce2 = ce.cloneWith({extension: "Value"});
 ```
 
-You can create a `CloudEvent` object in many ways, for example:
+You can create a `CloudEvent` object in many ways, for example, in TypeScript:
 
 ```js
 import { CloudEvent, CloudEventV1, CloudEventV1Attributes } from "cloudevents";


### PR DESCRIPTION
Fixes: #198 

## Description
Added some examples of the `CloudEvent` class usage.
@lance the `Event` type doesn't seem to be exported in the latest `cloudevents` package, so I didn't add that example.

Do let me know if you want any more changes 👍 