### PR TITLE
fix: use `isolatedModules: true` in tsconfig.json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,9 +16,15 @@ import CONSTANTS from "./constants";
 
 export {
   // From event
-  CloudEvent, Version,
-  ValidationError, Mode, HTTP,
-  Kafka, MQTT, MQTTMessageFactory, emitterFor,
+  CloudEvent,
+  Version,
+  ValidationError,
+  Mode,
+  HTTP,
+  Kafka,
+  MQTT,
+  MQTTMessageFactory,
+  emitterFor,
   Emitter,
   // From Constants
   CONSTANTS
@@ -28,12 +34,16 @@ export type {
   CloudEventV1,
   CloudEventV1Attributes,
   // From message
-  Headers, Binding,
+  Headers,
+  Binding,
   Message,
   Deserializer,
-  Serializer, KafkaEvent,
-  KafkaMessage, MQTTMessage,
+  Serializer,
+  KafkaEvent,
+  KafkaMessage,
+  MQTTMessage,
   // From transport
   TransportFunction,
-  EmitterFunction, Options
+  EmitterFunction,
+  Options
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,31 +16,24 @@ import CONSTANTS from "./constants";
 
 export {
   // From event
-  CloudEvent,
+  CloudEvent, Version,
+  ValidationError, Mode, HTTP,
+  Kafka, MQTT, MQTTMessageFactory, emitterFor,
+  Emitter,
+  // From Constants
+  CONSTANTS
+};
+
+export type {
   CloudEventV1,
   CloudEventV1Attributes,
-  Version,
-  ValidationError,
   // From message
-  Headers,
-  Mode,
-  Binding,
+  Headers, Binding,
   Message,
   Deserializer,
-  Serializer,
-  HTTP,
-  Kafka,
-  KafkaEvent,
-  KafkaMessage,
-  MQTT,
-  MQTTMessage,
-  MQTTMessageFactory,
+  Serializer, KafkaEvent,
+  KafkaMessage, MQTTMessage,
   // From transport
   TransportFunction,
-  EmitterFunction,
-  emitterFor,
-  Emitter,
-  Options,
-  // From Constants
-  CONSTANTS,
+  EmitterFunction, Options
 };

--- a/src/message/kafka/index.ts
+++ b/src/message/kafka/index.ts
@@ -10,7 +10,10 @@ import { sanitize } from "../http/headers";
 
 // Export the binding implementation and message interface
 export {
-  Kafka,
+  Kafka
+};
+
+export type {
   KafkaMessage,
   KafkaEvent
 };

--- a/src/message/mqtt/index.ts
+++ b/src/message/mqtt/index.ts
@@ -6,10 +6,9 @@
 import { Binding, Deserializer, CloudEvent, CloudEventV1, CONSTANTS, Message, ValidationError, Headers } from "../..";
 
 export {
-  MQTT,
-  MQTTMessage,
-  MQTTMessageFactory
+  MQTT, MQTTMessageFactory
 };
+export type { MQTTMessage };
 
 /**
  * Extends the base {@linkcode Message} interface to include MQTT attributes, some of which

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "forceConsistentCasingInFileNames": true,  /* Disallow inconsistently-cased references to the same file. */
     "outDir": "./dist",
     "declaration": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "isolatedModules": true,
   },
   "compileOnSave": true,
   "include": [


### PR DESCRIPTION
This setting ensures the module can be used in projects where the workflow
includes type checking and transpilation as two separate steps.

See: https://ncjamieson.com/dont-export-const-enums/

Fixes: https://github.com/cloudevents/sdk-javascript/issues/456

Signed-off-by: Lance Ball <lball@redhat.com>