### PR TITLE
chore: update the release documentation

### DIFF
--- a/RELEASE_GUIDELINES.md
+++ b/RELEASE_GUIDELINES.md
@@ -1,53 +1,17 @@
 # Module Release Guidelines
 
-## Create a Proposal Issue
+## `release-please`
 
-To prepare for a new release, create a [new issue](https://github.com/cloudevents/sdk-javascript/issues/new?assignees=&labels=&template=feature-request.md&title=) where the title of the issue cleary reflects the version to be released.
+This project uses [`release-please-action`](https://github.com/google-github-actions/release-please-action)
+to manage CHANGELOG.md and automate our releases. It does so by parsing the git history, looking for
+[Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages, and creating release PRs.
 
-For example: "Proposal for 3.2.0 release", or something similar.  If you are not sure which version is the next version to be released, you can run `npm run release -- --dry-run` to find out what the next version will be.
+For example: https://github.com/cloudevents/sdk-javascript/pull/475
 
-The body of the issue should be the commits that will be part of the release.  This can be easily accomplished by running a git log command with a defined **range**.  This range should start at the most recent version tag and end at the latest commit in the main branch.
-
-For example:
-
-```
-git log v3.0.1..upstream/main --oneline
-```
-
-This will output all the commits from the 3.0.1 tag to the latest commits in the remote upstream/main branch.
-
-This output should be pasted into the issue as normal text.  This will allow Github to magically turn all commit hashes and PR/Issues numbers to links.
-
-### Get Consensus
-
-Before a release can be finalized, other maintainers should give a +1 or a thumbs up or some other identifying mark that they are good with the changes.
-
-## Create and Publish the release
-
-Once consensus has been reached on the proposal it is time to create the release and publish it to npm.
-
-### Create the Release
-
-Creating the release is as simple as running the release script:
-
-```
-npm run release
-```
-
-This will update the CHANGELOG.md and create a new tag based on the version.  This can then be pushed upstream by doing:
-
-```
-git push upstream main --follow-tags
-```
-
-### Create the release on GitHub
-
-Once the release tag has been created and pushed up to Github, we should draft a new release using the Github UI, which is [located here](https://github.com/cloudevents/sdk-javascript/releases/new)
-
-* Tag Version should be the tag that was just created
-* The release title should be something like "VERSION Release"
-* And the Changelog entries for the current release should be copied/pasted into the comments
-
+Each time a commit lands on `main`, the workflow updates the pull request to include the commit message
+in CHANGELOG.md, and bump the version in package.json. When you are ready to create a new release, simply
+land the pull request. This will result in a release commit, updating CHANGELOG.md and package.json, a version
+tag is created on that commit SHA, and a release is drafted in github.com.
 
 ### Publish to npm
 
@@ -56,7 +20,3 @@ Once the new version has been created, we need to push it to npm.  Assuming you 
 ```
 npm publish
 ```
-
-## Close the Issue
-
-Once the release has been completed, the issue can be closed.


### PR DESCRIPTION
It has been out of date since we switched to using release-please
for our release automation.

Fixes: https://github.com/cloudevents/sdk-javascript/issues/474

Signed-off-by: Lance Ball <lball@redhat.com>
