### PR TITLE
doc: update maintainers in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,11 +212,15 @@ There you will find Express.js, TypeScript and Websocket examples.
   to determine which week will have the call.
 - Slack: #cloudeventssdk channel under
   [CNCF's Slack workspace](https://slack.cncf.io/).
-- Maintainers typically available on Slack
-  - Lance Ball
-  - Lucas Holmquist
-  - Grant Timmerman
 - Email: https://lists.cncf.io/g/cncf-cloudevents-sdk
+
+## Maintainers
+
+Currently active maintainers who may be found in the CNCF Slack.
+
+- Lance Ball (@lance)
+- Lucas Holmquist (@lholmquist)
+- Grant Timmerman (@grant)
 
 ## Contributing
 


### PR DESCRIPTION
This commit modifies the structure of the README.md to add a markdown
heading. This change is motiviated by the CLO tool provided by CNCF.
This repository is failing a check for maintainers as you can see on
the dashboard:
https://clomonitor.io/projects/cloudevents/cloudevents#sdk-javascript

Documentation for this change can be found here:
https://github.com/cncf/clomonitor/blob/main/docs/checks.md#maintainers

Signed-off-by: Lance Ball <lball@redhat.com>
