### PR TITLE
chore: add an npm test:once script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:fix": "eslint 'src/**/*.{js,ts}' 'test/**/*.{js,ts}' --fix",
     "pretest": "npm run lint && npm run conformance",
     "test": "mocha --require ts-node/register ./test/integration/**/*.ts",
+    "test:one": "mocha --require ts-node/register",
     "conformance": "cucumber-js ./conformance/features/*-protocol-binding.feature -p default",
     "coverage": "nyc --reporter=lcov --reporter=text npm run test",
     "coverage-publish": "wget -qO - https://coverage.codacy.com/get.sh | bash -s report -l JavaScript -r coverage/lcov.info",


### PR DESCRIPTION
Adds a convenience npm script that allows you to run only a single test
file at a time. Example usage:

```
sdk-javascript on  lance/update-deps-package-json [!?] is 📦 v5.3.2 via  v16.14.0
❯ npm run test:one

> cloudevents@5.3.2 test:one
> mocha --require ts-node/register

Error: No test files found

sdk-javascript on  lance/update-deps-package-json [!?] is 📦 v5.3.2 via  v16.14.0
❯ npm run test:one -- ./test/integration/batch_test.ts

> cloudevents@5.3.2 test:one
> mocha --require ts-node/register "./test/integration/batch_test.ts"

  A batched CloudEvent message over HTTP
    ✔ Can be created with a typed Message

  A batched CloudEvent message over Kafka
    ✔ Can be created with a typed Message

  2 passing (5ms)

sdk-javascript on  lance/update-deps-package-json [!?] is 📦 v5.3.2 via  v16.14.0
```

Signed-off-by: Lance Ball <lball@redhat.com>
