### PR TITLE
feat!: add http transport and remove axios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "@typescript-eslint/parser": "^4.29.0",
         "ajv-cli": "^5.0.0",
         "ajv-formats": "^2.1.1",
-        "axios": "^0.21.3",
         "chai": "~4.2.0",
         "eslint": "^7.32.0",
         "eslint-config-standard": "^16.0.3",
@@ -1749,15 +1748,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dev": true,
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
     "node_modules/bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -3395,26 +3385,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
       "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
       "dev": true
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.14.8",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/foreach": {
       "version": "2.0.5",
@@ -10350,15 +10320,6 @@
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
-    "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dev": true,
-      "requires": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
     "bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -11636,12 +11597,6 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
       "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
-      "dev": true
-    },
-    "follow-redirects": {
-      "version": "1.14.8",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
       "dev": true
     },
     "foreach": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@typescript-eslint/parser": "^4.29.0",
         "ajv-cli": "^5.0.0",
         "ajv-formats": "^2.1.1",
+        "axios": "^0.26.1",
         "chai": "~4.2.0",
         "eslint": "^7.32.0",
         "eslint-config-standard": "^16.0.3",
@@ -1748,6 +1749,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "node_modules/bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -3385,6 +3395,26 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
       "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/foreach": {
       "version": "2.0.5",
@@ -10320,6 +10350,15 @@
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
+    "axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -11597,6 +11636,12 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
       "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "dev": true
     },
     "foreach": {

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "@typescript-eslint/parser": "^4.29.0",
     "ajv-cli": "^5.0.0",
     "ajv-formats": "^2.1.1",
+    "axios": "^0.26.1",
     "chai": "~4.2.0",
     "eslint": "^7.32.0",
     "eslint-config-standard": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
     "@typescript-eslint/parser": "^4.29.0",
     "ajv-cli": "^5.0.0",
     "ajv-formats": "^2.1.1",
-    "axios": "^0.21.3",
     "chai": "~4.2.0",
     "eslint": "^7.32.0",
     "eslint-config-standard": "^16.0.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { ValidationError } from "./event/validation";
 import { CloudEventV1, CloudEventV1Attributes } from "./event/interfaces";
 
 import { Options, TransportFunction, EmitterFunction, emitterFor, Emitter } from "./transport/emitter";
+import { httpTransport, axiosTransport } from "./transport/http";
 import { 
   Headers, Mode, Binding, HTTP, Kafka, KafkaEvent, KafkaMessage, Message, MQTT, MQTTMessage, MQTTMessageFactory,
   Serializer, Deserializer } from "./message";
@@ -24,7 +25,9 @@ export {
   Kafka,
   MQTT,
   MQTTMessageFactory,
+  axiosTransport,
   emitterFor,
+  httpTransport,
   Emitter,
   // From Constants
   CONSTANTS

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { ValidationError } from "./event/validation";
 import { CloudEventV1, CloudEventV1Attributes } from "./event/interfaces";
 
 import { Options, TransportFunction, EmitterFunction, emitterFor, Emitter } from "./transport/emitter";
-import { httpTransport, axiosTransport } from "./transport/http";
+import { httpTransport } from "./transport/http";
 import { 
   Headers, Mode, Binding, HTTP, Kafka, KafkaEvent, KafkaMessage, Message, MQTT, MQTTMessage, MQTTMessageFactory,
   Serializer, Deserializer } from "./message";
@@ -25,7 +25,6 @@ export {
   Kafka,
   MQTT,
   MQTTMessageFactory,
-  axiosTransport,
   emitterFor,
   httpTransport,
   Emitter,

--- a/src/transport/http/index.ts
+++ b/src/transport/http/index.ts
@@ -7,23 +7,7 @@ import http, { OutgoingHttpHeaders } from "http";
 
 import { Message, Options } from "../..";
 import { TransportFunction } from "../emitter";
-import axios from "axios";
 import { RequestOptions } from "https";
-
-export function axiosTransport(sink: string): TransportFunction {
-  return function (message: Message, options?: Options): Promise<unknown> {
-    options = { ...options };
-    const headers = {
-      ...message.headers,
-      ...(options.headers as Record<string, string>),
-    };
-    delete options.headers;
-    return axios.post(sink, message.body, {
-      headers: headers,
-      ...options,
-    });
-  };
-}
 
 /**
  * httpTransport provides a simple HTTP Transport function, which can send a CloudEvent,

--- a/src/transport/http/index.ts
+++ b/src/transport/http/index.ts
@@ -3,10 +3,14 @@
  SPDX-License-Identifier: Apache-2.0
 */
 
-import { Message, Options } from "../..";
-import axios from "axios";
+import http, { OutgoingHttpHeaders } from "http";
 
-export function axiosEmitter(sink: string) {
+import { Message, Options } from "../..";
+import { TransportFunction } from "../emitter";
+import axios from "axios";
+import { RequestOptions } from "https";
+
+export function axiosTransport(sink: string): TransportFunction {
   return function (message: Message, options?: Options): Promise<unknown> {
     options = { ...options };
     const headers = {
@@ -17,6 +21,49 @@ export function axiosEmitter(sink: string) {
     return axios.post(sink, message.body, {
       headers: headers,
       ...options,
+    });
+  };
+}
+
+/**
+ * httpTransport provides a simple HTTP Transport function, which can send a CloudEvent,
+ * encoded as a Message to the endpoint. The returned function can be used with emitterFor()
+ * to provide an event emitter, for example:
+ * 
+ * const emitter = emitterFor(httpTransport("http://example.com"));
+ * emitter.emit(myCloudEvent)
+ *    .then(resp => console.log(resp));
+ * 
+ * @param {string|URL} sink the destination endpoint for the event
+ * @returns {TransportFunction} a function which can be used to send CloudEvents to _sink_
+ */
+export function httpTransport(sink: string | URL): TransportFunction {
+  return function(message: Message, options?: Options): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      options = { ...options };
+
+      // TODO: Callers should be able to set any Node.js RequestOptions
+      const opts: RequestOptions = {
+        method: "POST",
+        headers: {...message.headers, ...options.headers as OutgoingHttpHeaders},
+      };
+      try {
+        const response = {
+          body: "",
+          headers: {},
+        };
+        const req = http.request(sink, opts, (res) => {
+          res.setEncoding("utf-8");
+          response.headers = res.headers;
+          res.on("data", (chunk) => response.body += chunk);
+          res.on("end", () => { resolve(response); });
+        });
+        req.on("error", reject);
+        req.write(message.body);
+        req.end();
+      } catch (err) {
+        reject(err);
+      }
     });
   };
 }

--- a/test/integration/emitter_factory_test.ts
+++ b/test/integration/emitter_factory_test.ts
@@ -11,10 +11,12 @@ import request from "superagent";
 import got from "got";
 
 import CONSTANTS from "../../src/constants";
-import { CloudEvent, emitterFor, HTTP, Mode, Message, Options, TransportFunction } from "../../src";
+import { CloudEvent, HTTP, Message, Mode, Options, TransportFunction, 
+  axiosTransport, emitterFor, httpTransport }
+  from "../../src";
 
 const DEFAULT_CE_CONTENT_TYPE = CONSTANTS.DEFAULT_CE_CONTENT_TYPE;
-const sink = "https://cloudevents.io/";
+const sink = "http://cloudevents.io/";
 const type = "com.example.test";
 const source = "urn:event:from:myapi/resource/123";
 const ext1Name = "lunch";
@@ -83,7 +85,6 @@ describe("emitterFor() defaults", () => {
 
   it("Supports HTTP binding, structured mode", () => {
     function transport(message: Message): Promise<unknown> {
-      console.error(message);
       // A structured message will have the application/cloudevents+json header
       expect(message.headers["content-type"]).to.equal(CONSTANTS.DEFAULT_CE_CONTENT_TYPE);
       const body = JSON.parse(message.body as string);
@@ -114,6 +115,14 @@ describe("HTTP Transport Binding for emitterFactory", () => {
         const returnBody = { ...(body as Record<string, unknown>), ...this.req.headers };
         return [201, returnBody];
       });
+  });
+
+  describe("HTTP builtin", () => {
+    testEmitter(httpTransport(sink), "body");
+  });
+
+  describe("Axios builtin", () => {
+    testEmitter(axiosTransport(sink), "data");
   });
 
   describe("Axios", () => {

--- a/test/integration/emitter_factory_test.ts
+++ b/test/integration/emitter_factory_test.ts
@@ -11,8 +11,7 @@ import request from "superagent";
 import got from "got";
 
 import CONSTANTS from "../../src/constants";
-import { CloudEvent, HTTP, Message, Mode, Options, TransportFunction, 
-  axiosTransport, emitterFor, httpTransport }
+import { CloudEvent, HTTP, Message, Mode, Options, TransportFunction, emitterFor, httpTransport }
   from "../../src";
 
 const DEFAULT_CE_CONTENT_TYPE = CONSTANTS.DEFAULT_CE_CONTENT_TYPE;
@@ -119,10 +118,6 @@ describe("HTTP Transport Binding for emitterFactory", () => {
 
   describe("HTTP builtin", () => {
     testEmitter(httpTransport(sink), "body");
-  });
-
-  describe("Axios builtin", () => {
-    testEmitter(axiosTransport(sink), "data");
   });
 
   describe("Axios", () => {

--- a/test/integration/emitter_factory_test.ts
+++ b/test/integration/emitter_factory_test.ts
@@ -6,7 +6,7 @@
 import "mocha";
 import { expect } from "chai";
 import nock from "nock";
-import axios from "axios";
+import axios, { AxiosRequestHeaders } from "axios";
 import request from "superagent";
 import got from "got";
 
@@ -39,7 +39,7 @@ export const fixture = new CloudEvent({
 });
 
 function axiosEmitter(message: Message, options?: Options): Promise<unknown> {
-  return axios.post(sink, message.body, { headers: message.headers, ...options });
+  return axios.post(sink, message.body, { headers: message.headers as AxiosRequestHeaders, ...options });
 }
 
 function superagentEmitter(message: Message, options?: Options): Promise<unknown> {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,9 @@ module.exports = {
   },
   resolve: {
     fallback: {
-      util: require.resolve("util/")
+      util: require.resolve("util/"),
+      http: false,
+      https: false
     },
   },
   output: {


### PR DESCRIPTION
This commit adds a base HTTP emitter that can be used to send events over HTTP without requiring any additional dependencies. It uses the Node.js builtin HTTP module instead of a dependency on axios/got/whatever. I have also eliminated the `axiosEmitter` in the desire to eliminate the axios dependency. I've done this as a single commit, so it can be reverted if folks prefer to keep it.

~~Also, before landing this, I would like to add HTTPS support.~~ Done
