### PR TITLE
chore: update dependencies to inlude ajv-formats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,11 @@
   "packages": {
     "": {
       "name": "cloudevents",
-      "version": "5.3.2",
+      "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.6.3",
+        "ajv-formats": "^2.1.1",
         "util": "^0.12.4",
         "uuid": "^8.3.2"
       },
@@ -25,7 +26,6 @@
         "@typescript-eslint/eslint-plugin": "^4.29.0",
         "@typescript-eslint/parser": "^4.29.0",
         "ajv-cli": "^5.0.0",
-        "ajv-formats": "^2.1.1",
         "axios": "^0.26.1",
         "chai": "~4.2.0",
         "eslint": "^7.32.0",
@@ -1536,7 +1536,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "dev": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -10195,7 +10194,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "dev": true,
       "requires": {
         "ajv": "^8.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
   "homepage": "https://github.com/cloudevents/sdk-javascript#readme",
   "dependencies": {
     "ajv": "^8.6.3",
+    "ajv-formats": "^2.1.1",
     "util": "^0.12.4",
     "uuid": "^8.3.2"
   },
@@ -126,7 +127,6 @@
     "@typescript-eslint/eslint-plugin": "^4.29.0",
     "@typescript-eslint/parser": "^4.29.0",
     "ajv-cli": "^5.0.0",
-    "ajv-formats": "^2.1.1",
     "axios": "^0.26.1",
     "chai": "~4.2.0",
     "eslint": "^7.32.0",


### PR DESCRIPTION
In this PR https://github.com/cloudevents/sdk-javascript/pull/471/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R128
it was not noticed that the addition of `ajv-formats` to devDependencies
is insufficient. Unfortunately, users of v6.0.0 will receive an error when
using the module, unless they explicitly install `ajv-formats` in their
project. This commit fixes that, and should result in an immediate release
of version 6.0.1.

Signed-off-by: Lance Ball <lball@redhat.com>

<!-- General PR guidelines:
Thanks for taking the time to contribute to this project!

When submitting a pull request, please be sure to use the --signoff
flag for your commits. If you haven't done this already, you can
amend your most recent commit with "git commit --amend --signoff".

If your change fixes an existing problem, please add a close hook
to your commit message. For example, if your PR fixes issue #280
include the following in the description:

  Fixes: https://github.com/cloudevents/sdk-javascript/issues/280
 -->
## Proposed Changes

## Description
