### PR TITLE
fix: HTTP headers for extensions with false values

### DIFF
--- a/src/message/http/headers.ts
+++ b/src/message/http/headers.ts
@@ -36,7 +36,7 @@ export function headersFor<T>(event: CloudEventV1<T>): Headers {
   // iterate over the event properties - generate a header for each
   Object.getOwnPropertyNames(event).forEach((property) => {
     const value = event[property];
-    if (value) {
+    if (value !== undefined) {
       const map: MappedParser | undefined = headerMap[property] as MappedParser;
       if (map) {
         headers[map.name] = map.parser.parse(value as string) as string;

--- a/test/integration/message_test.ts
+++ b/test/integration/message_test.ts
@@ -41,6 +41,16 @@ const imageData = new Uint32Array(fs.readFileSync(path.join(process.cwd(), "test
 const image_base64 = asBase64(imageData);
 
 describe("HTTP transport", () => {
+  
+  it("Includes extensions when type is 'boolean' with a false value", () => {
+    const evt = new CloudEvent({ source: "test", type: "test", extboolean: false });
+    expect(evt.hasOwnProperty("extboolean")).to.equal(true);
+    expect(evt["extboolean"]).to.equal(false);
+    const message = HTTP.binary(evt);
+    expect(message.headers.hasOwnProperty("ce-extboolean")).to.equal(true);
+    expect(message.headers["ce-extboolean"]).to.equal(false);
+  });
+
   it("Handles events with no content-type and no datacontenttype", () => {
     const body = "{Something[Not:valid}JSON";
     const message: Message<undefined> = {

--- a/test/integration/message_test.ts
+++ b/test/integration/message_test.ts
@@ -42,13 +42,23 @@ const image_base64 = asBase64(imageData);
 
 describe("HTTP transport", () => {
   
-  it("Includes extensions when type is 'boolean' with a false value", () => {
+  it("Includes extensions in binary mode when type is 'boolean' with a false value", () => {
     const evt = new CloudEvent({ source: "test", type: "test", extboolean: false });
     expect(evt.hasOwnProperty("extboolean")).to.equal(true);
     expect(evt["extboolean"]).to.equal(false);
     const message = HTTP.binary(evt);
     expect(message.headers.hasOwnProperty("ce-extboolean")).to.equal(true);
     expect(message.headers["ce-extboolean"]).to.equal(false);
+  });
+
+  it("Includes extensions in structured when type is 'boolean' with a false value", () => {
+    const evt = new CloudEvent({ source: "test", type: "test", extboolean: false });
+    expect(evt.hasOwnProperty("extboolean")).to.equal(true);
+    expect(evt["extboolean"]).to.equal(false);
+    const message = HTTP.structured(evt);
+    const body = JSON.parse(message.body as string);
+    expect(body.hasOwnProperty("extboolean")).to.equal(true);
+    expect(body.extboolean).to.equal(false);
   });
 
   it("Handles events with no content-type and no datacontenttype", () => {


### PR DESCRIPTION
CloudEvent objects may include extensions that have a defined key and a
`false` value. This change ensures that HTTP messages for CloudEvents
containing these extension values include the appropriate headers.

Fixes: https://github.com/cloudevents/sdk-javascript/issues/492

Signed-off-by: Lance Ball <lball@redhat.com>
