### PR TITLE
fix: Make CloudEvent data field immutable and enumerable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ typings/
 
 # Package lock
 package-lock.json
+
+# Jetbrains IDE directories
+.idea

--- a/examples/express-ex/index.js
+++ b/examples/express-ex/index.js
@@ -28,11 +28,11 @@ app.post("/", (req, res) => {
     const responseEventMessage = new CloudEvent({
       source: '/',
       type: 'event:response',
-      ...event
+      ...event,
+      data: {
+        hello: 'world'
+      }
     });
-    responseEventMessage.data = {
-      hello: 'world'
-    };
 
     // const message = HTTP.binary(responseEventMessage)
     const message = HTTP.structured(responseEventMessage)

--- a/src/event/validation.ts
+++ b/src/event/validation.ts
@@ -8,6 +8,19 @@ import { ErrorObject } from "ajv";
 export type TypeArray = Int8Array | Uint8Array | Int16Array | Uint16Array | 
   Int32Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array;
 
+const globalThisPolyfill = (function() {
+  try {
+    return globalThis;
+  }
+  catch (e) {
+    try {
+      return self;
+    }
+    catch (e) {
+      return global;
+    }
+  }
+}());
 
 /**
  * An Error class that will be thrown when a CloudEvent
@@ -85,6 +98,14 @@ export const asBuffer = (value: string | Buffer | TypeArray): Buffer =>
     : (() => {
         throw new TypeError("is not buffer or a valid binary");
       })();
+
+export const base64AsBinary = (base64String: string): Uint8Array => {
+  const toBinaryString = (base64Str: string): string => globalThisPolyfill.atob
+    ? globalThisPolyfill.atob(base64Str)
+    : Buffer.from(base64Str, "base64").toString("binary");
+
+  return Uint8Array.from(toBinaryString(base64String), (c) => c.charCodeAt(0));
+};
 
 export const asBase64 = 
 (value: string | Buffer | TypeArray): string => asBuffer(value).toString("base64");

--- a/test/integration/mqtt_tests.ts
+++ b/test/integration/mqtt_tests.ts
@@ -32,12 +32,12 @@ const ext2Name = "extension2";
 const ext2Value = "acme";
 
 // Binary data as base64
-const dataBinary = Uint32Array.from(JSON.stringify(data), (c) => c.codePointAt(0) as number);
+const dataBinary = Uint8Array.from(JSON.stringify(data), (c) => c.codePointAt(0) as number);
 const data_base64 = asBase64(dataBinary);
 
 // Since the above is a special case (string as binary), let's test
 // with a real binary file one is likely to encounter in the wild
-const imageData = new Uint32Array(fs.readFileSync(path.join(process.cwd(), "test", "integration", "ce.png")));
+const imageData = new Uint8Array(fs.readFileSync(path.join(process.cwd(), "test", "integration", "ce.png")));
 const image_base64 = asBase64(imageData);
 
 const PUBLISH = {"Content Type": "application/json; charset=utf-8"};
@@ -281,14 +281,14 @@ describe("MQTT transport", () => {
 
   it("Converts base64 encoded data to binary when deserializing structured messages", () => {
     const message = MQTT.structured(fixture.cloneWith({ data: imageData, datacontenttype: "image/png" }));
-    const eventDeserialized = MQTT.toEvent(message) as CloudEvent<Uint32Array>;
+    const eventDeserialized = MQTT.toEvent(message) as CloudEvent<Uint8Array>;
     expect(eventDeserialized.data).to.deep.equal(imageData);
     expect(eventDeserialized.data_base64).to.equal(image_base64);
   });
 
   it("Converts base64 encoded data to binary when deserializing binary messages", () => {
     const message = MQTT.binary(fixture.cloneWith({ data: imageData, datacontenttype: "image/png" }));
-    const eventDeserialized = MQTT.toEvent(message) as CloudEvent<Uint32Array>;
+    const eventDeserialized = MQTT.toEvent(message) as CloudEvent<Uint8Array>;
     expect(eventDeserialized.data).to.deep.equal(imageData);
     expect(eventDeserialized.data_base64).to.equal(image_base64);
   });
@@ -302,7 +302,7 @@ describe("MQTT transport", () => {
 
   it("Does not parse binary data from binary messages with content type application/json", () => {
     const message = MQTT.binary(fixture.cloneWith({ data: dataBinary }));
-    const eventDeserialized = MQTT.toEvent(message) as CloudEvent<Uint32Array>;
+    const eventDeserialized = MQTT.toEvent(message) as CloudEvent<Uint8Array>;
     expect(eventDeserialized.data).to.deep.equal(dataBinary);
     expect(eventDeserialized.data_base64).to.equal(data_base64);
   });

--- a/test/integration/spec_1_tests.ts
+++ b/test/integration/spec_1_tests.ts
@@ -19,7 +19,7 @@ const data = {
 };
 const subject = "subject-x0";
 
-let cloudevent = new CloudEvent({
+const cloudevent = new CloudEvent({
   specversion: Version.V1,
   id,
   source,
@@ -120,8 +120,8 @@ describe("CloudEvents Spec v1.0", () => {
       });
 
       it("defaut ID create when an empty string", () => {
-        cloudevent = cloudevent.cloneWith({ id: "" });
-        expect(cloudevent.id.length).to.be.greaterThan(0);
+        const testEvent = cloudevent.cloneWith({ id: "" });
+        expect(testEvent.id.length).to.be.greaterThan(0);
       });
     });
 
@@ -160,11 +160,11 @@ describe("CloudEvents Spec v1.0", () => {
     describe("'time'", () => {
       it("must adhere to the format specified in RFC 3339", () => {
         const d = new Date();
-        cloudevent = cloudevent.cloneWith({ time: d.toString() }, false);
+        const testEvent = cloudevent.cloneWith({ time: d.toString() }, false);
         // ensure that we always get back the same thing we passed in
-        expect(cloudevent.time).to.equal(d.toString());
+        expect(testEvent.time).to.equal(d.toString());
         // ensure that when stringified, the timestamp is in RFC3339 format
-        expect(JSON.parse(JSON.stringify(cloudevent)).time).to.equal(new Date(d.toString()).toISOString());
+        expect(JSON.parse(JSON.stringify(testEvent)).time).to.equal(new Date(d.toString()).toISOString());
       });
     });
   });


### PR DESCRIPTION
## Proposed Changes
* CloudEvent class:
  * Make data field immutable like the other fields in the class
  * Make data field enumerable via `Object.keys()` and `Object.entries()`
  * toJSON() does not return a `data` field anymore if `data_base64` is set to comply with the JSON format spec 3.1.1 `Out of this follows that the presence of the data and data_base64 members is mutually exclusive in a JSON serialized CloudEvent.`

Fixes https://github.com/cloudevents/sdk-javascript/issues/515
