### PR TITLE
chore: add the build script to the pretest script.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,9 @@
         "typescript": "^4.3.5",
         "webpack": "^5.74.0",
         "webpack-cli": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=12 <20.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:js": "eslint 'src/**/*.{js,ts}' 'test/**/*.{js,ts}' cucumber.js",
     "lint:md": "remark .",
     "lint:fix": "eslint 'src/**/*.{js,ts}' 'test/**/*.{js,ts}' --fix",
-    "pretest": "npm run lint && npm run conformance",
+    "pretest": "npm run lint && npm run build && npm run conformance",
     "test": "mocha --require ts-node/register ./test/integration/**/*.ts",
     "test:one": "mocha --require ts-node/register",
     "conformance": "cucumber-js ./conformance/features/*-protocol-binding.feature -p default",


### PR DESCRIPTION
Currently, to run the tests successfully, `npm run build` needs to be run first in order to `ajv compile` the schema.  We started to run into this when we added this library to the test suite that runs these tests on RHEL and Fedora platforms in our node.js container.

see https://github.com/sclorg/s2i-nodejs-container/pull/384

error for reference:

```
TSError: ⨯ Unable to compile TypeScript:
src/event/spec.ts:10:22 - error TS2307: Cannot find module '../schema/v1' or its corresponding type declarations.

10 import validate from "../schema/v1";
                        ~~~~~~~~~~~~~~

    at createTSError (/Users/lholmqui/develop/cloudevents/sdk-javascript/node_modules/ts-node/src/index.ts:859:12)
    at reportTSError (/Users/lholmqui/develop/cloudevents/sdk-javascript/node_modules/ts-node/src/index.ts:863:19)
    at getOutput (/Users/lholmqui/develop/cloudevents/sdk-javascript/node_modules/ts-node/src/index.ts:1077:36)
    at Object.compile (/Users/lholmqui/develop/cloudevents/sdk-javascript/node_modules/ts-node/src/index.ts:1433:41)
    at Module.m._compile (/Users/lholmqui/develop/cloudevents/sdk-javascript/node_modules/ts-node/src/index.ts:1617:30)
    at Module._extensions..js (node:internal/modules/cjs/loader:1272:10)
    at Object.require.extensions.<computed> [as .ts] (/Users/lholmqui/develop/cloudevents/sdk-javascript/node_modules/ts-node/src/index.ts:1621:12)
    at Module.load (node:internal/modules/cjs/loader:1081:32)
    at Function.Module._load (node:internal/modules/cjs/loader:922:12)
    at Module.require (node:internal/modules/cjs/loader:1105:19)
```




