### PR TITLE
chore: remove old Node versions from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ _Note:_ Supports CloudEvent version 1.0
 ## Installation
 
 The CloudEvents SDK requires a current LTS version of Node.js. At the moment
-those are Node.js 12.x, Node.js 14.x, Node.js 16.x, and Node.js 18.x. To install in your Node.js project:
+those are Node.js 16.x, and Node.js 18.x. To install in your Node.js project:
 
 ```console
 npm install cloudevents


### PR DESCRIPTION
This just removes the mention of the old node versions from the readme