### PR TITLE
chore: Update compatible node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,6 @@
   },
   "types": "./dist/index.d.ts",
   "engines": {
-    "node": ">=16 <=20.0.0"
+    "node": ">=16 <=20"
   }
 }


### PR DESCRIPTION
## Proposed Changes

Allow Node 20.x

## Description

Now you allow only Node 20.0.0, let's make it compatible with all Node 20.x.x versions.