### PR TITLE
chore: fix the release-please automation script.

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v3
+        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: node


### PR DESCRIPTION
The id of release was left out, so the checks to see if there needs to be a publish were being skipped

see https://github.com/cloudevents/sdk-javascript/actions/runs/5133682126/jobs/9236610689


