### PR TITLE
chore: add `npm run build:schema` to the doc generation action

### DIFF
--- a/.github/workflows/api-docs.yaml
+++ b/.github/workflows/api-docs.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
       -
         name: Generate API documentation
-        run: npm install && npm run generate-docs
+        run: npm install && npm run build:schema && npm run generate-docs
       -
         name: Deploy to GitHub Pages
         if: success()


### PR DESCRIPTION
The github action that generates the documentation fails currently due to the fact that it's expecting the generated schema to exist, but it does not exist unless it's explicitly built.

This commit adds `npm run build:schema` to the workflow action.
