### PR TITLE
chore: modify release-please to use Signed-Off-By on commits

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,4 +13,5 @@ jobs:
           token: ${{ secrets.CLOUDEVENTS_RELEASES_TOKEN }}
           release-type: node
           package-name: cloudevents
+          signoff: "Lucas Holmquist <lholmqui@redhat.com>"
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"docs","section":"Documentation","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false},{"type":"src","section":"Miscellaneous","hidden":false},{"type":"style","section":"Miscellaneous","hidden":false},{"type":"refactor","section":"Miscellaneous","hidden":false},{"type":"perf","section":"Performance","hidden":false},{"type":"test","section":"Tests","hidden":false}]'

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "webpack-cli": "^4.10.0"
       },
       "engines": {
-        "node": ">=16 <=20.0.0"
+        "node": ">=16 <=20"
       }
     },
     "node_modules/@ampproject/remapping": {


### PR DESCRIPTION
Modifies the release-please github action to add a "Signed-Off-By" line at the end of the commit, placating DCO.

@lholmquist I used your signoff since the release-please action seems to make the commits as you.