### PR TITLE
fix: allow Node 22 LTS and use it by default

### DIFF
--- a/.github/workflows/api-docs.yaml
+++ b/.github/workflows/api-docs.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       -
         name: Generate API documentation
         run: npm install && npm run build:schema && npm run generate-docs

--- a/.github/workflows/nodejs-ci-action.yml
+++ b/.github/workflows/nodejs-ci-action.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 21.x]
+        node-version: [16.x, 18.x, 20.x, 22.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Test on Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
@@ -31,18 +31,18 @@ jobs:
     name: Code coverage
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Generate coverage report
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
-        node-version: 18.x
+        node-version: 22.x
     - run: npm ci
     - run: npm run build --if-present
     - run: npm run coverage
     - name: Upload coverage report to storage
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: coverage
         path: coverage/lcov.info
@@ -52,15 +52,15 @@ jobs:
     needs: coverage
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Download coverage report from storage
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v4
       with:
         name: coverage
     - name: Upload coverage report to codacy
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
-        node-version: 18.x
+        node-version: 22.x
     - run: |
         ( [[ "${CODACY_PROJECT_TOKEN}" != ""  ]] && npm run coverage-publish ) || echo "Coverage report not published"
       env:

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -9,10 +9,10 @@ jobs:
      contents: read
      id-token: write
    steps:
-     - uses: actions/checkout@v3
-     - uses: actions/setup-node@v3
+     - uses: actions/checkout@v4
+     - uses: actions/setup-node@v4
        with:
-         node-version: '18.x'
+         node-version: '22.x'
          registry-url: 'https://registry.npmjs.org'
      - run: npm install -g npm
      - run: npm ci

--- a/package.json
+++ b/package.json
@@ -160,6 +160,6 @@
   },
   "types": "./dist/index.d.ts",
   "engines": {
-    "node": ">=16 <=21"
+    "node": ">=16 <=22"
   }
 }


### PR DESCRIPTION
<!-- General PR guidelines:
Thanks for taking the time to contribute to this project!

When submitting a pull request, please be sure to use the --signoff
flag for your commits. If you haven't done this already, you can
amend your most recent commit with "git commit --amend --signoff".

If your change fixes an existing problem, please add a close hook
to your commit message. For example, if your PR fixes issue #280
include the following in the description:

  Fixes: https://github.com/cloudevents/sdk-javascript/issues/280
 -->
## Proposed Changes

Add compatibility for released LTS Node 22
Move some Github actions to their latest versions

## Description
