### PR TITLE
fix: creating an event does not error when the event attribute name is too long

### DIFF
--- a/src/event/cloudevent.ts
+++ b/src/event/cloudevent.ts
@@ -109,9 +109,9 @@ export class CloudEvent<T = undefined> implements CloudEventV1<T> {
 
     // finally process any remaining properties - these are extensions
     for (const [key, value] of Object.entries(properties)) {
-      // Extension names should only allow lowercase a-z and 0-9 in the name
+      // Extension names must only allow lowercase a-z and 0-9 in the name
       // names should not exceed 20 characters in length
-      if (!key.match(/^[a-z0-9]{1,20}$/) && strict) {
+      if (!key.match(/^[a-z0-9]+$/) && strict) {
         throw new ValidationError(`invalid extension name: ${key}
 CloudEvents attribute names MUST consist of lower-case letters ('a' to 'z')
 or digits ('0' to '9') from the ASCII character set. Attribute names SHOULD

--- a/test/integration/cloud_event_test.ts
+++ b/test/integration/cloud_event_test.ts
@@ -82,10 +82,10 @@ describe("A CloudEvent", () => {
     }).throw("invalid extension name");
   });
 
-  it("Throw a validation error for invalid extension names, more than 20 chars", () => {
+  it("Not throw a validation error for invalid extension names, more than 20 chars", () => {
     expect(() => {
       new CloudEvent({ "123456789012345678901": "extension1", ...fixture });
-    }).throw("invalid extension name");
+    }).not.throw("invalid extension name");
   });
 
   it("Throws a validation error for invalid uppercase extension names", () => {


### PR DESCRIPTION
From the spec, the requirement for the length of attribute names is only a `SHOULD`, not a `MUST`. Currently, if the length is over 20 then the sdk throws an error, which I believe is incorrect because the length requirement is not a `MUST`.

## Proposed Changes
- When an event attribute has a name lonoger than 2o characters, the SDK does not throw an error anymore
