### PR TITLE
fix: add generics to `Binding` type

### DIFF
--- a/src/message/index.ts
+++ b/src/message/index.ts
@@ -22,9 +22,9 @@ export * from "./mqtt";
  * @property {@link Deserializer} `toEvent`  - converts a Message into a CloudEvent
  * @property {@link Detector} `isEvent`      - determines if a Message can be converted to a CloudEvent
  */
-export interface Binding {
-  binary: Serializer;
-  structured: Serializer;
+export interface Binding<B extends Message = Message, S extends Message = Message> {
+  binary: Serializer<B>;
+  structured: Serializer<S>;
   toEvent: Deserializer;
   isEvent: Detector;
 }
@@ -65,8 +65,8 @@ export enum Mode {
  * CloudEvent into a Message.
  * @interface
  */
-export interface Serializer {
-  <T>(event: CloudEventV1<T>): Message;
+export interface Serializer<M extends Message> {
+  <T>(event: CloudEventV1<T>): M;
 }
 
 /**

--- a/src/message/mqtt/index.ts
+++ b/src/message/mqtt/index.ts
@@ -15,7 +15,7 @@ export type { MQTTMessage };
  * Extends the base {@linkcode Message} interface to include MQTT attributes, some of which
  * are aliases of the {Message} attributes.
  */
-interface MQTTMessage<T> extends Message<T> {
+interface MQTTMessage<T = unknown> extends Message<T> {
   /**
    * Identifies this message as a PUBLISH packet. MQTTMessages created with
    * the `binary` and `structured` Serializers will contain a "Content Type"
@@ -37,7 +37,7 @@ interface MQTTMessage<T> extends Message<T> {
  * Binding for MQTT transport support
  * @implements @linkcode Binding
  */
-const MQTT: Binding = {
+const MQTT: Binding<MQTTMessage, MQTTMessage> = {
   binary,
   structured,
   toEvent: toEvent as Deserializer,


### PR DESCRIPTION
<!-- General PR guidelines:
Thanks for taking the time to contribute to this project!

When submitting a pull request, please be sure to use the --signoff
flag for your commits. If you haven't done this already, you can
amend your most recent commit with "git commit --amend --signoff".

If your change fixes an existing problem, please add a close hook
to your commit message. For example, if your PR fixes issue #280
include the following in the description:

  Fixes: https://github.com/cloudevents/sdk-javascript/issues/280
 -->
## Proposed Changes

* Add generics to the `Binding` type so that the typings of the values returned by `binary` and `structured` can be more exact. 
* Fix the typing on `KafkaMessage` so that `T` is authoritative of the type of `value`.

Fixes: https://github.com/cloudevents/sdk-javascript/issues/487

## Description

The typing changes are not perfect, but they are closer to reality and backward compatible. They should remove a decent chunk of `as` casting in client code.