### PR TITLE
feat!: remove node 16

### DIFF
--- a/.github/workflows/nodejs-ci-action.yml
+++ b/.github/workflows/nodejs-ci-action.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "webpack-cli": "^4.10.0"
       },
       "engines": {
-        "node": ">=16 <=20"
+        "node": ">=18 <=22"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -160,6 +160,6 @@
   },
   "types": "./dist/index.d.ts",
   "engines": {
-    "node": ">=16 <=22"
+    "node": ">=18 <=22"
   }
 }


### PR DESCRIPTION
Node 16 has been EOL for a while now and it is time to remove it as a supported version.

I've tag this as a breaking change
