### PR TITLE
feat: kafka message protocol example

### DIFF
--- a/examples/kafka-ex/package.json
+++ b/examples/kafka-ex/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "kafka-ex",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc",
+    "start:producer": "ts-node src/producer.ts",
+    "start:consumer": "ts-node src/consumer.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "Apache-2.0",
+  "type": "commonjs",
+  "dependencies": {
+    "cloudevents": "^10.0.0",
+    "kafkajs": "^2.2.4",
+    "ts-node": "^10.9.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.2",
+    "typescript": "^5.7.3"
+  }
+}

--- a/examples/kafka-ex/package.json
+++ b/examples/kafka-ex/package.json
@@ -1,8 +1,8 @@
 {
   "name": "kafka-ex",
+  "description": "Simple kafka example using CloudEvents",
+  "repository": "https://github.com/cloudevents/sdk-javascript.git",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
   "scripts": {
     "build": "tsc",
     "start:producer": "ts-node src/producer.ts",

--- a/examples/kafka-ex/src/admin.ts
+++ b/examples/kafka-ex/src/admin.ts
@@ -1,0 +1,16 @@
+/* eslint-disable */
+import kafka from "./client";
+
+(async () => {
+  const admin = kafka.admin();
+  await admin.connect();
+  await admin.createTopics({
+    topics: [
+      {
+        topic: "events.cloudevents.test",
+        numPartitions: 2,
+      },
+    ],
+  });
+  await admin.disconnect();
+})();

--- a/examples/kafka-ex/src/client.ts
+++ b/examples/kafka-ex/src/client.ts
@@ -1,0 +1,10 @@
+/* eslint-disable */
+
+import { Kafka } from "kafkajs";
+
+const kafka = new Kafka({
+  clientId: "kafka-ex-client-id",
+  brokers: ["localhost:9092"],
+});
+
+export default kafka;

--- a/examples/kafka-ex/src/consumer.ts
+++ b/examples/kafka-ex/src/consumer.ts
@@ -1,0 +1,48 @@
+/* eslint-disable */
+import { Headers, Kafka, Message } from "cloudevents";
+import kafka from "./client";
+
+const groupId = process.argv[2];
+
+console.log(process.argv, groupId);
+
+(async () => {
+  const consumer = kafka.consumer({ groupId });
+  await consumer.connect();
+
+  consumer.subscribe({ topic: "events.cloudevents.test" });
+
+  consumer.run({
+    eachMessage: async ({ topic, partition, message }) => {
+      console.log("Raw Kafka message:", {
+        topic,
+        partition,
+        offset: message.offset,
+        headers: message.headers,
+        value: message.value?.toString(),
+      });
+
+      try {
+        let newHeaders: Headers = {};
+        Object.keys(message.headers as Headers).forEach((key) => {
+          // this is needed here because the headers are buffer values 
+          // when it gets to the consumer which is invalid for the 
+          // toEvent api from cloudevents, so this converts each key value to a string
+          // as expected by the toEvent api
+          newHeaders[key] = message!.headers![key]?.toString() ?? "";
+        });
+
+        message.headers = newHeaders;
+        const messageValue = Kafka.toEvent(
+          message as unknown as Message<string>
+        );
+
+        console.log("Deserialized CloudEvent:", messageValue);
+        // message is automatically acknowledged when the callback is finished
+      } catch (error) {
+        console.error("Error deserializing CloudEvent:", error);
+        console.log("Raw message value:", message.value?.toString());
+      }
+    },
+  });
+})();

--- a/examples/kafka-ex/src/producer.ts
+++ b/examples/kafka-ex/src/producer.ts
@@ -1,0 +1,40 @@
+/* eslint-disable */
+import { CloudEvent, Kafka } from "cloudevents";
+import readline from "readline";
+import kafka from "./client";
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+(async () => {
+  const producer = kafka.producer();
+  await producer.connect();
+
+  rl.setPrompt("> ");
+  rl.prompt();
+  rl.on("line", async (line) => {
+    const event = new CloudEvent({
+      source: "cloudevents-producer",
+      type: "events.cloudevents.test",
+      datacontenttype: "text/plain",
+      partitionkey: "1",
+      data: line,
+    });
+
+    const message = Kafka.structured(event);
+    
+    await producer.send({
+      topic: "events.cloudevents.test",
+      messages: [
+        message
+      ],
+    });
+    rl.prompt();
+  });
+
+  rl.on("close", async () => {
+    await producer.disconnect();
+  });
+})();


### PR DESCRIPTION
## Proposed Changes
Added a sample end to end example for kafka message protocol. 

## Description
It is a simple cli application where from user input, the kafka producer sends a CloudEvent message to a topic. And eventually, the cloudevent message is handled and deserialized correctly by a consumer subscribed to the same topic.

Message sent from the Producer (CLI Input)
<img width="1180" height="288" alt="Screenshot 2025-09-21 at 00 36 05" src="https://github.com/user-attachments/assets/30991492-6394-4e63-bb89-e3f80bb18d7b" />

Message received and deserialised by the Consumer
<img width="1472" height="351" alt="Screenshot 2025-09-21 at 00 35 51" src="https://github.com/user-attachments/assets/531749f1-a800-4799-a28c-b3460236c1e1" />


## Fixes this Issue
https://github.com/cloudevents/sdk-javascript/issues/463
 


