### PR TITLE
fix!: decode data_base64 as Uint8Array instead of Uint32Array

### DIFF
--- a/src/message/http/index.ts
+++ b/src/message/http/index.ts
@@ -16,7 +16,7 @@ import {
   v1binaryParsers,
   v1structuredParsers,
 } from "./headers";
-import { isStringOrObjectOrThrow, ValidationError } from "../../event/validation";
+import { base64AsBinary, isStringOrObjectOrThrow, ValidationError } from "../../event/validation";
 import { JSONParser, MappedParser, Parser, parserByContentType } from "../../parsers";
 
 /**
@@ -248,7 +248,7 @@ function parseStructured<T>(message: Message, version: string): CloudEvent<T> {
   // itself will be encoded as base64
   if (eventObj.data_base64 || eventObj.datacontentencoding === CONSTANTS.ENCODING_BASE64) {
     const data = eventObj.data_base64 || eventObj.data;
-    eventObj.data = new Uint32Array(Buffer.from(data as string, "base64"));
+    eventObj.data = base64AsBinary(data as string);
     delete eventObj.data_base64;
     delete eventObj.datacontentencoding;
   }

--- a/test/integration/cloud_event_test.ts
+++ b/test/integration/cloud_event_test.ts
@@ -22,7 +22,7 @@ const fixture = Object.freeze({
   data: `"some data"`
 });
 
-const imageData = new Uint32Array(fs.readFileSync(path.join(process.cwd(), "test", "integration", "ce.png")));
+const imageData = new Uint8Array(fs.readFileSync(path.join(process.cwd(), "test", "integration", "ce.png")));
 const image_base64 = asBase64(imageData);
 
 // Do not replace this with the assignment of a class instance

--- a/test/integration/kafka_tests.ts
+++ b/test/integration/kafka_tests.ts
@@ -34,12 +34,12 @@ const ext2Name = "extension2";
 const ext2Value = "acme";
 
 // Binary data as base64
-const dataBinary = Uint32Array.from(JSON.stringify(data), (c) => c.codePointAt(0) as number);
+const dataBinary = Uint8Array.from(JSON.stringify(data), (c) => c.codePointAt(0) as number);
 const data_base64 = asBase64(dataBinary);
 
 // Since the above is a special case (string as binary), let's test
 // with a real binary file one is likely to encounter in the wild
-const imageData = new Uint32Array(fs.readFileSync(path.join(process.cwd(), "test", "integration", "ce.png")));
+const imageData = new Uint8Array(fs.readFileSync(path.join(process.cwd(), "test", "integration", "ce.png")));
 const image_base64 = asBase64(imageData);
 
 const fixture = new CloudEvent({
@@ -289,14 +289,14 @@ describe("Kafka transport", () => {
 
   it.skip("Converts base64 encoded data to binary when deserializing structured messages", () => {
     const message = Kafka.structured(fixture.cloneWith({ data: imageData, datacontenttype: "image/png" }));
-    const eventDeserialized = Kafka.toEvent(message) as CloudEvent<Uint32Array>;
+    const eventDeserialized = Kafka.toEvent(message) as CloudEvent<Uint8Array>;
     expect(eventDeserialized.data).to.deep.equal(imageData);
     expect(eventDeserialized.data_base64).to.equal(image_base64);
   });
 
   it("Converts base64 encoded data to binary when deserializing binary messages", () => {
     const message = Kafka.binary(fixture.cloneWith({ data: imageData, datacontenttype: "image/png" }));
-    const eventDeserialized = Kafka.toEvent(message) as CloudEvent<Uint32Array>;
+    const eventDeserialized = Kafka.toEvent(message) as CloudEvent<Uint8Array>;
     expect(eventDeserialized.data).to.deep.equal(imageData);
     expect(eventDeserialized.data_base64).to.equal(image_base64);
   });
@@ -310,7 +310,7 @@ describe("Kafka transport", () => {
 
   it("Does not parse binary data from binary messages with content type application/json", () => {
     const message = Kafka.binary(fixture.cloneWith({ data: dataBinary }));
-    const eventDeserialized = Kafka.toEvent(message) as CloudEvent<Uint32Array>;
+    const eventDeserialized = Kafka.toEvent(message) as CloudEvent<Uint8Array>;
     expect(eventDeserialized.data).to.deep.equal(dataBinary);
     expect(eventDeserialized.data_base64).to.equal(data_base64);
   });

--- a/test/integration/message_test.ts
+++ b/test/integration/message_test.ts
@@ -32,12 +32,12 @@ const ext2Name = "extension2";
 const ext2Value = "acme";
 
 // Binary data as base64
-const dataBinary = Uint32Array.from(JSON.stringify(data), (c) => c.codePointAt(0) as number);
+const dataBinary = Uint8Array.from(JSON.stringify(data), (c) => c.codePointAt(0) as number);
 const data_base64 = asBase64(dataBinary);
 
 // Since the above is a special case (string as binary), let's test
 // with a real binary file one is likely to encounter in the wild
-const imageData = new Uint32Array(fs.readFileSync(path.join(process.cwd(), "test", "integration", "ce.png")));
+const imageData = new Uint8Array(fs.readFileSync(path.join(process.cwd(), "test", "integration", "ce.png")));
 const image_base64 = asBase64(imageData);
 
 describe("HTTP transport", () => {
@@ -317,21 +317,32 @@ describe("HTTP transport", () => {
 
     it("Converts base64 encoded data to binary when deserializing structured messages", () => {
       const message = HTTP.structured(fixture.cloneWith({ data: imageData, datacontenttype: "image/png" }));
-      const eventDeserialized = HTTP.toEvent(message) as CloudEvent<Uint32Array>;
+      const eventDeserialized = HTTP.toEvent(message) as CloudEvent<Uint8Array>;
       expect(eventDeserialized.data).to.deep.equal(imageData);
       expect(eventDeserialized.data_base64).to.equal(image_base64);
     });
 
     it("Does not parse binary data from structured messages with content type application/json", () => {
       const message = HTTP.structured(fixture.cloneWith({ data: dataBinary }));
-      const eventDeserialized = HTTP.toEvent(message) as CloudEvent<Uint32Array>;
+      const eventDeserialized = HTTP.toEvent(message) as CloudEvent<Uint8Array>;
       expect(eventDeserialized.data).to.deep.equal(dataBinary);
       expect(eventDeserialized.data_base64).to.equal(data_base64);
     });
 
+    it("Deserializes data_base64 as Uint8Array with correct byte length", () => {
+      const original = new Uint8Array([0x00, 0x01, 0x02, 0xff]);
+      const event = fixture.cloneWith({ data: original, datacontenttype: "application/octet-stream" });
+      const message = HTTP.structured(event);
+      const deserialized = HTTP.toEvent(message) as CloudEvent<Uint8Array>;
+      expect(deserialized.data).to.be.instanceOf(Uint8Array);
+      expect(deserialized.data!.length).to.equal(4);
+      expect(deserialized.data!.buffer.byteLength).to.equal(4);
+      expect(Array.from(deserialized.data!)).to.deep.equal([0x00, 0x01, 0x02, 0xff]);
+    });
+
     it("Converts base64 encoded data to binary when deserializing binary messages", () => {
       const message = HTTP.binary(fixture.cloneWith({ data: imageData, datacontenttype: "image/png" }));
-      const eventDeserialized = HTTP.toEvent(message) as CloudEvent<Uint32Array>;
+      const eventDeserialized = HTTP.toEvent(message) as CloudEvent<Uint8Array>;
       expect(eventDeserialized.data).to.deep.equal(imageData);
       expect(eventDeserialized.data_base64).to.equal(image_base64);
     });
@@ -345,7 +356,7 @@ describe("HTTP transport", () => {
 
     it("Does not parse binary data from binary messages with content type application/json", () => {
       const message = HTTP.binary(fixture.cloneWith({ data: dataBinary }));
-      const eventDeserialized = HTTP.toEvent(message) as CloudEvent<Uint32Array>;
+      const eventDeserialized = HTTP.toEvent(message) as CloudEvent<Uint8Array>;
       expect(eventDeserialized.data).to.deep.equal(dataBinary);
       expect(eventDeserialized.data_base64).to.equal(data_base64);
     });
@@ -422,14 +433,14 @@ describe("HTTP transport", () => {
       // Creating an event with binary data automatically produces base64 encoded data
       // which is then set as the 'data' attribute on the message body
       const message = HTTP.structured(fixture.cloneWith({ data: imageData, datacontenttype: "image/png" }));
-      const eventDeserialized = HTTP.toEvent(message) as CloudEvent<Uint32Array>;
+      const eventDeserialized = HTTP.toEvent(message) as CloudEvent<Uint8Array>;
       expect(eventDeserialized.data).to.deep.equal(imageData);
       expect(eventDeserialized.data_base64).to.equal(image_base64);
     });
 
     it("Converts base64 encoded data to binary when deserializing binary messages", () => {
       const message = HTTP.binary(fixture.cloneWith({ data: imageData, datacontenttype: "image/png" }));
-      const eventDeserialized = HTTP.toEvent(message) as CloudEvent<Uint32Array>;
+      const eventDeserialized = HTTP.toEvent(message) as CloudEvent<Uint8Array>;
       expect(eventDeserialized.data).to.deep.equal(imageData);
       expect(eventDeserialized.data_base64).to.equal(image_base64);
     });


### PR DESCRIPTION
`parseStructured()` decodes `data_base64` into a `Uint32Array` instead of `Uint8Array`, producing binary data with a corrupted underlying `ArrayBuffer`.

The existing code:

```js
eventObj.data = new Uint32Array(Buffer.from(data, "base64"));
```

This stores each byte value (0–255) in a 32-bit element. The numeric *values* are correct, so consumers using `Buffer.from(typedArray)` (which copies values element-by-element) happen to get the right bytes. But any consumer that reads the underlying `ArrayBuffer` directly (such as protobuf libraries) sees 4 bytes per element with null-byte padding, resulting in silently corrupted data.

`Uint32Array` was introduced as the SDK's internal binary representation around #491 / #494, which fixed the **encoding** direction (creating CloudEvents with binary data). The **decoding** path in `parseStructured` was never updated. Notably, the SDK's own `base64AsBinary()` in `event/validation.ts` already correctly uses `Uint8Array`.

**Proposed Changes**

- Replace the inline `new Uint32Array(Buffer.from(...))` with a call to the existing `base64AsBinary()` helper, which returns a proper `Uint8Array`
- Update all test fixtures from `Uint32Array` to `Uint8Array` to match
- Add a new test that explicitly asserts `event.data` is a `Uint8Array` with correct `buffer.byteLength`

**Breaking change note**

I have flagged this PR as a breaking change because it changes the runtime type of `event.data` from `Uint32Array` to `Uint8Array` for structured-mode CloudEvents with `data_base64`. Code that checks `instanceof Uint32Array` or relies on `BYTES_PER_ELEMENT === 4` would break.

However, the current `Uint32Array` behavior is a bug and `Uint8Array` is the correct type for binary data. It's unlikely any consumer intentionally depends on `Uint32Array`. So this could potentially be safe as a patch/minor fix rather than requiring a major version bump.

Fixes: https://github.com/cloudevents/sdk-javascript/issues/643