### PR TITLE
refactor: drop the @ts-ignore from ValidationError

### DIFF
--- a/src/event/validation.ts
+++ b/src/event/validation.ts
@@ -30,17 +30,13 @@ export class ValidationError extends TypeError {
   errors?: string[] | ErrorObject[] | null;
 
   constructor(message: string, errors?: string[] | ErrorObject[] | null) {
-    const messageString =
-      errors instanceof Array
-        ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          errors?.reduce(
-            (accum: string, err: Record<string, string>) =>
-              accum.concat(`
+    const validationErrors: Array<string | ErrorObject> = errors instanceof Array ? errors : [];
+    const messageString = validationErrors.reduce<string>(
+      (accum, err) =>
+        accum.concat(`
   ${err instanceof Object ? JSON.stringify(err) : err}`),
-            message,
-          )
-        : message;
+      message,
+    );
     super(messageString);
     this.errors = errors ? errors : [];
   }

--- a/test/integration/utilities_test.ts
+++ b/test/integration/utilities_test.ts
@@ -5,7 +5,43 @@
 
 import "mocha";
 import { expect } from "chai";
-import { isStringOrThrow, equalsOrThrow, isBase64, asData } from "../../src/event/validation";
+import { ValidationError, isStringOrThrow, equalsOrThrow, isBase64, asData } from "../../src/event/validation";
+
+describe("ValidationError", () => {
+  it("includes string errors in its message", () => {
+    const errors = ["source is required", "type is required"];
+
+    const error = new ValidationError("invalid payload", errors);
+
+    expect(error.message).to.equal(`invalid payload
+  source is required
+  type is required`);
+    expect(error.errors).to.equal(errors);
+  });
+
+  it("includes AJV errors as JSON in its message", () => {
+    const errors = [
+      {
+        instancePath: "/source",
+        schemaPath: "#/properties/source/minLength",
+        keyword: "minLength",
+        params: { limit: 1 },
+        message: "must NOT have fewer than 1 characters",
+      },
+    ];
+
+    const error = new ValidationError("invalid payload", errors);
+
+    expect(error.message).to.equal(`invalid payload
+  ${JSON.stringify(errors[0])}`);
+    expect(error.errors).to.equal(errors);
+  });
+
+  it("keeps the original message when no errors are provided", () => {
+    expect(new ValidationError("invalid payload").message).to.equal("invalid payload");
+    expect(new ValidationError("invalid payload", null).message).to.equal("invalid payload");
+  });
+});
 
 describe("Utilities", () => {
   describe("isStringOrThrow", () => {


### PR DESCRIPTION
## Proposed Changes

Remove the `@ts-ignore` from `ValidationError`.

## Description

Type the local error array as `Array<string | ErrorObject>` so TypeScript can check the `reduce()` call without changing runtime behavior. Focused tests cover string, Ajv, and missing errors.
