### PR TITLE
feat!: remove Node.js 20 support

### DIFF
--- a/.github/workflows/nodejs-ci-action.yml
+++ b/.github/workflows/nodejs-ci-action.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ _Note:_ Supports CloudEvent version 1.0
 ## Installation
 
 The CloudEvents SDK requires a current LTS version of Node.js. At the moment
-those are Node.js 16.x, and Node.js 18.x. To install in your Node.js project:
+those are Node.js 22.x, and Node.js 24.x. To install in your Node.js project:
 
 ```console
 npm install cloudevents

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "webpack-cli": "^4.10.0"
       },
       "engines": {
-        "node": ">=20 <=24"
+        "node": ">=22 <=24"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -160,6 +160,6 @@
   },
   "types": "./dist/index.d.ts",
   "engines": {
-    "node": ">=20 <=24"
+    "node": ">=22 <=24"
   }
 }


### PR DESCRIPTION
## Proposed Changes

Remove Node.js 20 support.

## Description

Node.js 20 has reached end-of-life. Raise the minimum supported version to Node.js 22 and update the CI matrix and README.